### PR TITLE
Add isFullMatchSystems to automation

### DIFF
--- a/automation/metarunners/MandatoryUpdate.xml
+++ b/automation/metarunners/MandatoryUpdate.xml
@@ -16,13 +16,14 @@
             <param name="ACTIVE_LINE_PERIOD" value="0" spec="text description='Active line period (days)' validationMode='not_empty' display='normal'" />
             <param name="EXCLUDE_COMPONENTS" value="" spec="text description='Exclude components (comma‑separated)' validationMode='any' display='normal'" />
             <param name="EXCLUDE_SYSTEMS" value="" spec="text description='Systems with which components will be excluded (comma-separated)' validationMode='any' display='normal'" />
+            <param name="IS_FULL_MATCH_SYSTEMS" value="true" spec="text description='Possible values are |'true|' or |'false|'' validationMode='not_empty' display='normal'" />
             <param name="OUTPUT_FILE" value="" spec="text description='File to save result' validationMode='any' display='normal'" />
             <param name="DRY_RUN" value="true" spec="text description='Dry run only, do not apply. Possible values are |'true|' or |'false|'' validationMode='not_empty' display='normal'" />
         </parameters>
         <build-runners>
             <runner name="Create Mandatory Update" type="OctopusReleaseManagementAutomation">
                 <parameters>
-                    <param name="ARGS" value="--url=%RELEASE_MANAGEMENT_SERVICE_URL% mandatory-update --component=%COMPONENT_NAME% --version=%COMPONENT_VERSION% --project-key=%PROJECT_KEY% --epic-name='%EPIC_NAME%' --due-date=%DUE_DATE% --customer=%CUSTOMER% --notice='%NOTICE%' --active-line-period=%ACTIVE_LINE_PERIOD% --exclude-components=%EXCLUDE_COMPONENTS% --exclude-systems=%EXCLUDE_SYSTEMS% --output-file=%OUTPUT_FILE% --dry-run=%DRY_RUN%" />
+                    <param name="ARGS" value="--url=%RELEASE_MANAGEMENT_SERVICE_URL% mandatory-update --component=%COMPONENT_NAME% --version=%COMPONENT_VERSION% --project-key=%PROJECT_KEY% --epic-name='%EPIC_NAME%' --due-date=%DUE_DATE% --customer=%CUSTOMER% --notice='%NOTICE%' --active-line-period=%ACTIVE_LINE_PERIOD% --exclude-components=%EXCLUDE_COMPONENTS% --exclude-systems=%EXCLUDE_SYSTEMS% --is-full-match-systems=%IS_FULL_MATCH_SYSTEMS% --output-file=%OUTPUT_FILE% --dry-run=%DRY_RUN%" />
                 </parameters>
             </runner>
         </build-runners>

--- a/automation/src/main/kotlin/org/octopusden/octopus/automation/releasemanagement/command/MandatoryUpdate.kt
+++ b/automation/src/main/kotlin/org/octopusden/octopus/automation/releasemanagement/command/MandatoryUpdate.kt
@@ -79,6 +79,11 @@ class MandatoryUpdate : CliktCommand(name = COMMAND) {
         }
         .default(emptySet())
 
+    private val isFullMatchSystems by option(IS_FULL_MATCH_SYSTEMS, help = "Exclude components by systems match strategy: " +
+            "true - exclude only if component systems fully match exclude-systems; false - exclude if component has any system from exclude-systems")
+        .convert { it.toBooleanStrictOrNull() ?: throw IllegalArgumentException("$IS_FULL_MATCH_SYSTEMS must be 'true' or 'false'") }
+        .required()
+
     private val outputFile by option(OUTPUT_FILE, help = "File to save result")
         .convert { it.trim() }
         .default("")
@@ -91,7 +96,8 @@ class MandatoryUpdate : CliktCommand(name = COMMAND) {
         val filter = MandatoryUpdateFilterDTO(
             activeLinePeriod = activeLinePeriod,
             excludeComponents = excludeComponents,
-            excludeSystems = excludeSystems
+            excludeSystems = excludeSystems,
+            isFullMatchSystems = isFullMatchSystems
         )
         val dto = MandatoryUpdateDTO(
             component = component,
@@ -127,6 +133,7 @@ class MandatoryUpdate : CliktCommand(name = COMMAND) {
         const val ACTIVE_LINE_PERIOD = "--active-line-period"
         const val EXCLUDE_COMPONENTS = "--exclude-components"
         const val EXCLUDE_SYSTEMS = "--exclude-systems"
+        const val IS_FULL_MATCH_SYSTEMS = "--is-full-match-systems"
         const val OUTPUT_FILE = "--output-file"
         const val DRY_RUN = "--dry-run"
     }

--- a/ft/src/ft/kotlin/org/octopusden/octopus/releasemanagementservice/AutomationTest.kt
+++ b/ft/src/ft/kotlin/org/octopusden/octopus/releasemanagementservice/AutomationTest.kt
@@ -47,6 +47,7 @@ class AutomationTest : BaseReleaseManagementServiceFuncTest {
             "${MandatoryUpdate.DUE_DATE}=2025-08-15",
             "${MandatoryUpdate.CUSTOMER}=Octopus",
             "${MandatoryUpdate.DRY_RUN}=false",
+            "${MandatoryUpdate.IS_FULL_MATCH_SYSTEMS}=true",
             "${MandatoryUpdate.ACTIVE_LINE_PERIOD}=180",
             "${MandatoryUpdate.OUTPUT_FILE}=${outFile.absolutePath}"
         )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a configurable option to Mandatory Update to control how excluded systems are matched. A new parameter IS_FULL_MATCH_SYSTEMS (true/false, default: true) is available in the meta-runner and as the CLI flag --is-full-match-systems. This lets you choose whether exclusions require a full systems match or allow partial matches, providing more precise control over which components are included in a mandatory update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->