### PR TITLE
Migrate tests to OKD

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ val defaultVersion = "${
         update(InetAddress.getLocalHost().hostName.toByteArray())
         value
     }
-}-snapshot"
+}-SNAPSHOT"
 
 allprojects {
     group = "org.octopusden.octopus.release-management-service"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import org.octopusden.task.MigrateMockData
+import java.net.InetAddress
+import java.util.zip.CRC32
 
 plugins {
     java
@@ -11,8 +12,18 @@ plugins {
     signing
 }
 
+val defaultVersion = "${
+    with(CRC32()) {
+        update(InetAddress.getLocalHost().hostName.toByteArray())
+        value
+    }
+}-snapshot"
+
 allprojects {
     group = "org.octopusden.octopus.release-management-service"
+    if (version == "unspecified") {
+        version = defaultVersion
+    }
 }
 
 nexusPublishing {
@@ -60,36 +71,49 @@ subprojects {
 
     tasks.withType<Test> {
         useJUnitPlatform()
-
         testLogging{
             info.events = setOf(TestLogEvent.FAILED, TestLogEvent.PASSED, TestLogEvent.SKIPPED)
         }
-
         systemProperties["release-management-service.version"] = version
-    }
-
-    val migrateMockData by tasks.creating(MigrateMockData::class) {
-        this.testDataDir = rootDir.toString() + File.separator + "test-data"
     }
 
     ext {
         System.getenv().let {
             set("signingRequired", it.containsKey("ORG_GRADLE_PROJECT_signingKey") && it.containsKey("ORG_GRADLE_PROJECT_signingPassword"))
+            set("testPlatform", it.getOrDefault("TEST_PLATFORM", properties["test.platform"]))
             set("dockerRegistry", it.getOrDefault("DOCKER_REGISTRY", properties["docker.registry"]))
-            set("octopusGithubDockerRegistry", it.getOrDefault("OCTOPUS_GITHUB_DOCKER_REGISTRY", properties["octopus.github.docker.registry"]))
+            set("octopusGithubDockerRegistry", it.getOrDefault("OCTOPUS_GITHUB_DOCKER_REGISTRY", project.properties["octopus.github.docker.registry"]))
+            set("okdActiveDeadlineSeconds", it.getOrDefault("OKD_ACTIVE_DEADLINE_SECONDS", properties["okd.active-deadline-seconds"]))
+            set("okdProject", it.getOrDefault("OKD_PROJECT", properties["okd.project"]))
+            set("okdClusterDomain", it.getOrDefault("OKD_CLUSTER_DOMAIN", properties["okd.cluster-domain"]))
+            set("okdWebConsoleUrl", (it.getOrDefault("OKD_WEB_CONSOLE_URL", properties["okd.web-console-url"]) as String).trimEnd('/'))
         }
-        set("validateFun", { properties: List<String> ->
-            val emptyProperties = properties.filter { (project.ext[it] as? String).isNullOrBlank() }
-            if (emptyProperties.isNotEmpty()) {
-                throw IllegalArgumentException(
-                    "Start gradle build with" +
-                            (if (emptyProperties.contains("dockerRegistry")) " -Pdocker.registry=..." else "") +
-                            (if (emptyProperties.contains("octopusGithubDockerRegistry")) " -Poctopus.github.docker.registry=..." else "") +
-                            " or set env variable(s):" +
-                            (if (emptyProperties.contains("dockerRegistry")) " DOCKER_REGISTRY" else "") +
-                            (if (emptyProperties.contains("octopusGithubDockerRegistry")) " OCTOPUS_GITHUB_DOCKER_REGISTRY" else "")
-                )
-            }
-        })
+    }
+    val supportedTestPlatforms = listOf("docker", "okd")
+    if (project.ext["testPlatform"] !in supportedTestPlatforms) {
+        throw IllegalArgumentException("Test platform must be set to one of the following $supportedTestPlatforms. Start gradle build with -Ptest.platform=... or set env variable TEST_PLATFORM")
+    }
+    val mandatoryProperties = mutableListOf("dockerRegistry", "octopusGithubDockerRegistry")
+    if (project.ext["testPlatform"] == "okd") {
+        mandatoryProperties.add("okdActiveDeadlineSeconds")
+        mandatoryProperties.add("okdProject")
+        mandatoryProperties.add("okdClusterDomain")
+    }
+    val undefinedProperties = mandatoryProperties.filter { (project.ext[it] as String).isBlank() }
+    if (undefinedProperties.isNotEmpty()) {
+        throw IllegalArgumentException(
+            "Start gradle build with" +
+                    (if (undefinedProperties.contains("dockerRegistry")) " -Pdocker.registry=..." else "") +
+                    (if (undefinedProperties.contains("octopusGithubDockerRegistry")) " -Poctopus.github.docker.registry=..." else "") +
+                    (if (undefinedProperties.contains("okdActiveDeadlineSeconds")) " -Pokd.active-deadline-seconds=..." else "") +
+                    (if (undefinedProperties.contains("okdProject")) " -Pokd.project=..." else "") +
+                    (if (undefinedProperties.contains("okdClusterDomain")) " -Pokd.cluster-domain=..." else "") +
+                    " or set env variable(s):" +
+                    (if (undefinedProperties.contains("dockerRegistry")) " DOCKER_REGISTRY" else "") +
+                    (if (undefinedProperties.contains("octopusGithubDockerRegistry")) " OCTOPUS_GITHUB_DOCKER_REGISTRY" else "") +
+                    (if (undefinedProperties.contains("okdActiveDeadlineSeconds")) " OKD_ACTIVE_DEADLINE_SECONDS" else "") +
+                    (if (undefinedProperties.contains("okdProject")) " OKD_PROJECT" else "") +
+                    (if (undefinedProperties.contains("okdClusterDomain")) " OKD_CLUSTER_DOMAIN" else "")
+        )
     }
 }

--- a/buildSrc/src/main/kotlin/org/octopusden/task/MigrateMockData.kt
+++ b/buildSrc/src/main/kotlin/org/octopusden/task/MigrateMockData.kt
@@ -4,6 +4,7 @@ import com.google.common.io.Files
 import com.google.common.net.HttpHeaders
 import org.apache.http.entity.ContentType
 import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 import org.mockserver.client.MockServerClient
@@ -14,26 +15,29 @@ import java.io.File
 import java.nio.charset.Charset
 
 
-open class MigrateMockData : DefaultTask() {
-
-    private val mockServerClient = MockServerClient("localhost", 1080)
-
+abstract class MigrateMockData : DefaultTask() {
     @get:Input
-    lateinit var testDataDir: String
+    abstract val host: Property<String>
+    @get:Input
+    abstract val port: Property<Int>
+    @get:Input
+    abstract val testDataDir: Property<String>
+
+    private val mockServerClient get() = MockServerClient(host.get(), port.get())
 
     @TaskAction
     fun startMockServer() {
         mockServerClient.reset()
         endpointToResponseFileName.forEach {
-            generateMockserverData(it.key.first, it.key.second, testDataDir + File.separator + it.value, HttpStatusCode.OK_200.code())
+            generateMockserverData(it.key.first, it.key.second, testDataDir.get() + File.separator + it.value, HttpStatusCode.OK_200.code())
         }
         endpointNotFoundToResponseFileName.forEach {
-            generateMockserverData(it.key.first, it.key.second, testDataDir + File.separator + it.value, HttpStatusCode.NOT_FOUND_404.code())
+            generateMockserverData(it.key.first, it.key.second, testDataDir.get() + File.separator + it.value, HttpStatusCode.NOT_FOUND_404.code())
         }
         generateMockserverData(
             "/rest/api/latest/issue",
             emptyMap(),
-            testDataDir + File.separator + "jira/create-issue.json",
+            testDataDir.get() + File.separator + "jira/create-issue.json",
             HttpStatusCode.CREATED_201.code(),
             "POST"
         )

--- a/ft/build.gradle.kts
+++ b/ft/build.gradle.kts
@@ -1,30 +1,10 @@
+import com.avast.gradle.dockercompose.ComposeExtension
+import org.gradle.kotlin.dsl.provideDelegate
+import org.octopusden.task.MigrateMockData
+
 plugins {
     id("com.avast.gradle.docker-compose")
-}
-
-@Suppress("UNCHECKED_CAST")
-val extValidateFun = project.ext["validateFun"] as ((List<String>) -> Unit)
-fun String.getExt() = project.ext[this] as? String
-
-
-configure<com.avast.gradle.dockercompose.ComposeExtension> {
-    useComposeFiles.add(layout.projectDirectory.file("docker/docker-compose.yml").asFile.path)
-    waitForTcpPorts.set(true)
-    captureContainersOutputToFiles.set(layout.buildDirectory.dir("docker-logs"))
-    environment.putAll(
-        mapOf(
-            "RELEASE_MANAGEMENT_SERVICE_VERSION" to version,
-            "OCTOPUS_COMPONENTS_REGISTRY_SERVICE_VERSION" to properties["octopus-components-registry.version"],
-            "MOCKSERVER_VERSION" to properties["mockserver.version"],
-            "TEAMCITY_VERSION" to "2022.04.7",
-            "DOCKER_REGISTRY" to "dockerRegistry".getExt(),
-            "OCTOPUS_GITHUB_DOCKER_REGISTRY" to "octopusGithubDockerRegistry".getExt()
-        )
-    )
-}
-
-tasks.getByName("composeUp").doFirst {
-    extValidateFun.invoke(listOf("dockerRegistry", "octopusGithubDockerRegistry"))
+    id("org.octopusden.octopus.oc-template")
 }
 
 sourceSets {
@@ -42,41 +22,238 @@ ftImplementation.isCanBeResolved = true
 
 configurations["ftRuntimeOnly"].extendsFrom(configurations.runtimeOnly.get())
 
+tasks {
+    val migrateMockData by registering(MigrateMockData::class)
+}
+
+configure<ComposeExtension> {
+    useComposeFiles.add(layout.projectDirectory.file("docker/docker-compose.yml").asFile.path)
+    waitForTcpPorts.set(true)
+    captureContainersOutputToFiles.set(layout.buildDirectory.dir("docker-logs"))
+    environment.putAll(
+        mapOf(
+            "RELEASE_MANAGEMENT_SERVICE_VERSION" to version,
+            "OCTOPUS_COMPONENTS_REGISTRY_SERVICE_VERSION" to properties["octopus-components-registry.version"],
+            "MOCKSERVER_VERSION" to properties["mockserver.version"],
+            "TEAMCITY_2022_IMAGE_TAG" to properties["teamcity-2022.image-tag"],
+            "DOCKER_REGISTRY" to "dockerRegistry".getExt(),
+            "OCTOPUS_GITHUB_DOCKER_REGISTRY" to "octopusGithubDockerRegistry".getExt(),
+            "TEST_MOCKSERVER_HOST" to "mockserver:1080",
+            "TEST_COMPONENTS_REGISTRY_HOST" to "components-registry-service:4567"
+        )
+    )
+}
+
+tasks.register<Copy>("deployTeamcity2022Plugin") {
+    dependsOn(prepareTeamcity2022Data)
+    dependsOn(":release-management-teamcity-plugin:serverPlugin")
+    from(rootProject.project("release-management-teamcity-plugin").configurations["distributions"].artifacts.files)
+    into(layout.buildDirectory.dir("teamcity-server-2022/datadir/plugins"))
+}
+
+tasks.named("composeUp") {
+    dependsOn(":release-management-service:dockerBuildImage")
+    dependsOn("deployTeamcity2022Plugin")
+}
+
+val prepareTeamcity2022Data = tasks.register<Sync>("prepareTeamcity2022Data") {
+    from(zipTree(layout.projectDirectory.file("docker/data.zip")))
+    into(layout.buildDirectory.dir("teamcity-server-2022"))
+}
+
+fun String.getExt() = project.ext[this] as String
+fun String.getPort() = when (this) {
+    "teamcity22" -> 8111
+    "comp-reg" -> 4567
+    "mockserver" -> 1080
+    "rm" -> 8080
+    else -> throw Exception("Unknown service '$this'")
+}
+fun getOkdExternalHost(serviceName: String) = "${ocTemplate.getPod(serviceName)}-service:${serviceName.getPort()}"
+
+val commonOkdParameters = mapOf(
+    "ACTIVE_DEADLINE_SECONDS" to "okdActiveDeadlineSeconds".getExt(),
+    "DOCKER_REGISTRY" to "dockerRegistry".getExt()
+)
+
+ocTemplate {
+    workDir.set(layout.buildDirectory.dir("okd"))
+    clusterDomain.set("okdClusterDomain".getExt())
+    namespace.set("okdProject".getExt())
+    prefix.set("rm-service-ft")
+
+    "okdWebConsoleUrl".getExt().takeIf { it.isNotBlank() }?.let {
+        webConsoleUrl.set(it)
+    }
+
+    group("teamcityPVC").apply {
+        service("teamcity22-pvc") {
+            templateFile.set(rootProject.layout.projectDirectory.file("okd/teamcity-pvc.yaml"))
+            parameters.set(mapOf(
+                "TEAMCITY_ID" to "22"
+            ))
+        }
+    }
+
+    group("teamcitySeedUploader").apply {
+        service("teamcity22-uploader") {
+            templateFile.set(rootProject.layout.projectDirectory.file("okd/teamcity-uploader.yaml"))
+            parameters.set(mapOf(
+                "SERVICE_ACCOUNT_ANYUID" to project.properties["okd.service-account-anyuid"] as String,
+                "ACTIVE_DEADLINE_SECONDS" to "okdActiveDeadlineSeconds".getExt(),
+                "TEAMCITY_ID" to "22"
+            ))
+        }
+    }
+
+    group("teamcityServer").apply {
+        service("teamcity22") {
+            templateFile.set(rootProject.layout.projectDirectory.file("okd/teamcity.yaml"))
+            parameters.set(commonOkdParameters + mapOf(
+                "SERVICE_ACCOUNT_ANYUID" to project.properties["okd.service-account-anyuid"] as String,
+                "TEAMCITY_IMAGE_TAG" to properties["teamcity-2022.image-tag"] as String,
+                "TEAMCITY_ID" to "22"
+            ))
+        }
+    }
+
+    group("teamcityAgent").apply {
+        service("tc22-agent") {
+            templateFile.set(rootProject.layout.projectDirectory.file("okd/teamcity-agent.yaml"))
+            parameters.set(commonOkdParameters + mapOf(
+                "SERVICE_ACCOUNT_ANYUID" to project.properties["okd.service-account-anyuid"] as String,
+                "TEAMCITY_IMAGE_TAG" to properties["teamcity-2022.image-tag"] as String,
+                "TEAMCITY_ID" to "22",
+                "TEAMCITY_SERVER_HOST" to getOkdExternalHost("teamcity22").replace(":", "\\:"),
+                "BUILD_AGENT_PROPERTIES_CONTENT" to layout.projectDirectory.dir("docker/buildAgent.properties").asFile.readText()
+            ))
+        }
+    }
+
+    group("componentsRegistry").apply {
+        service("comp-reg") {
+            templateFile.set(rootProject.layout.projectDirectory.file("okd/components-registry.yaml"))
+            val componentsRegistryWorkDir = layout.projectDirectory.dir("../test-common/src/main/components-registry").asFile.absolutePath
+            parameters.set(commonOkdParameters + mapOf(
+                "COMPONENTS_REGISTRY_SERVICE_VERSION" to properties["octopus-components-registry.version"] as String,
+                "AGGREGATOR_GROOVY_CONTENT" to file("${componentsRegistryWorkDir}/Aggregator.groovy").readText(),
+                "DEFAULTS_GROOVY_CONTENT" to file("${componentsRegistryWorkDir}/Defaults.groovy").readText(),
+                "TEST_COMPONENTS_GROOVY_CONTENT" to file("${componentsRegistryWorkDir}/TestComponents.groovy").readText(),
+                "APPLICATION_FT_CONTENT" to layout.projectDirectory.dir("docker/components-registry-service.yaml").asFile.readText()
+            ))
+        }
+    }
+
+    group("mockserver").apply {
+        service("mockserver") {
+            templateFile.set(rootProject.layout.projectDirectory.file("okd/mockserver.yaml"))
+            parameters.set(commonOkdParameters + mapOf(
+                "MOCK_SERVER_VERSION" to properties["mockserver.version"] as String
+            ))
+        }
+    }
+
+    group("releaseManagement").apply {
+        service("rm") {
+            templateFile.set(rootProject.layout.projectDirectory.file("okd/release-management.yaml"))
+            parameters.set(commonOkdParameters + mapOf(
+                "RELEASE_MANAGEMENT_SERVICE_VERSION" to version as String,
+                "OCTOPUS_GITHUB_DOCKER_REGISTRY" to "octopusGithubDockerRegistry".getExt(),
+                "APPLICATION_FT_CONTENT" to layout.projectDirectory.dir("docker/application-ft.yml").asFile.readText(),
+                "BOOTSTRAP_FT_CONTENT" to layout.projectDirectory.dir("docker/bootstrap-ft.yml").asFile.readText(),
+                "TEST_MOCKSERVER_HOST" to getOkdExternalHost("mockserver"),
+                "TEST_COMPONENTS_REGISTRY_HOST" to getOkdExternalHost("comp-reg")
+            ))
+        }
+    }
+}
+
+val copyTeamcity2022Plugin = tasks.register<Exec>("copyTeamcity2022Plugin") {
+    dependsOn("ocCreateTeamcityPVC", "ocCreateTeamcitySeedUploader")
+    dependsOn(":release-management-teamcity-plugin:serverPlugin")
+    val pluginFile = rootProject.project("release-management-teamcity-plugin").configurations["distributions"].artifacts.files.asPath
+    commandLine("oc", "cp", pluginFile, "-n", "okdProject".getExt(),
+        "${ocTemplate.getPod("teamcity22-uploader")}:/data/teamcity_server/datadir/plugins")
+}
+
+val copyFilesTeamcity2022 = tasks.register<Exec>("copyFilesTeamcity2022") {
+    dependsOn(copyTeamcity2022Plugin)
+    val localFile = layout.projectDirectory.dir("docker/data.zip").asFile.absolutePath
+    commandLine("oc", "cp", localFile, "-n", "okdProject".getExt(),
+        "${ocTemplate.getPod("teamcity22-uploader")}:/seed/seed.zip")
+}
+
+val seedTeamcity = tasks.register("seedTeamcity") {
+    dependsOn(copyFilesTeamcity2022)
+    finalizedBy("ocLogsTeamcitySeedUploader", "ocDeleteTeamcitySeedUploader")
+}
+
+tasks.named("ocCreateTeamcityServer").configure {
+    dependsOn(seedTeamcity)
+}
+
+tasks.named("ocDeleteTeamcityPVC").configure {
+    dependsOn("ocDeleteTeamcityServer")
+}
+
+tasks.named("ocCreateReleaseManagement") {
+    dependsOn(":release-management-service:dockerPushImage")
+}
+
+tasks.named<MigrateMockData>("migrateMockData") {
+    testDataDir.set(rootDir.toString() + File.separator + "test-data")
+    when ("testPlatform".getExt()) {
+        "okd" -> {
+            host.set(ocTemplate.getOkdHost("mockserver"))
+            port.set(80)
+            dependsOn("ocCreateMockserver")
+        }
+        "docker" -> {
+            host.set("localhost")
+            port.set(1080)
+            dependsOn("composeUp")
+        }
+    }
+}
+
 val ft by tasks.creating(Test::class) {
     group = "verification"
     description = "Runs the integration tests"
 
     testClassesDirs = sourceSets["ft"].output.classesDirs
     classpath = sourceSets["ft"].runtimeClasspath
-}
 
-dockerCompose.isRequiredBy(ft)
-
-val teamcityDir = layout.buildDirectory.dir("teamcity-server")
-
-tasks.register<Sync>("prepareTeamcityServerData") {
-    from(zipTree(layout.projectDirectory.file("docker/data.zip")))
-    into(teamcityDir)
-}
-
-tasks.register<Copy>("deployTeamcityPlugin") {
-    dependsOn("prepareTeamcityServerData")
-    dependsOn(":release-management-teamcity-plugin:serverPlugin")
-    from(rootProject.project("release-management-teamcity-plugin").configurations["distributions"].artifacts.files)
-    into(teamcityDir.get().dir("datadir/plugins"))
-}
-
-tasks.named("composeUp") {
-    dependsOn(":release-management-service:dockerBuildImage")
-    dependsOn("deployTeamcityPlugin")
-}
-
-tasks.named("migrateMockData") {
-    dependsOn("composeUp")
-}
-
-tasks.named("ft") {
-    dependsOn("migrateMockData")
+    when ("testPlatform".getExt()) {
+        "okd" -> {
+            systemProperties["test.release-management-host"] = ocTemplate.getOkdHost("rm")
+            systemProperties["test.release-management-host-for-teamcity"] = ocTemplate.getOkdHost("rm")
+            systemProperties["test.teamcity-2022-host"] = ocTemplate.getOkdHost("teamcity22")
+            dependsOn(
+                "ocCreateTeamcityServer",
+                "ocCreateTeamcityAgent",
+                "migrateMockData",
+                "ocCreateComponentsRegistry",
+                "ocCreateReleaseManagement"
+            )
+            finalizedBy(
+                "ocLogsTeamcityServer",
+                "ocLogsTeamcityAgent",
+                "ocLogsComponentsRegistry",
+                "ocLogsMockserver",
+                "ocDeleteTeamcityPVC",
+                "ocDeleteTeamcityAgent",
+                "ocDeleteComponentsRegistry",
+                "ocDeleteMockserver"
+            )
+        }
+        "docker" -> {
+            systemProperties["test.release-management-host"] = "localhost:8080"
+            systemProperties["test.release-management-host-for-teamcity"] = "release-management-service:8080"
+            systemProperties["test.teamcity-2022-host"] = "localhost:8111"
+            dependsOn("migrateMockData")
+            finalizedBy("composeLogs", "composeDown")
+        }
+    }
 }
 
 idea.module {

--- a/ft/docker/application-ft.yml
+++ b/ft/docker/application-ft.yml
@@ -1,13 +1,13 @@
 releng:
-  url: http://mockserver:1080
+  url: http://${TEST_MOCKSERVER_HOST}
 
 jira1:
-  host: http://mockserver:1080
+  host: http://${TEST_MOCKSERVER_HOST}
   username: admin
   password: admin
 
 components-registry-service:
-  url: http://components-registry-service:4567
+  url: http://${TEST_COMPONENTS_REGISTRY_HOST}
 
 management:
   endpoints:

--- a/ft/docker/docker-compose.yml
+++ b/ft/docker/docker-compose.yml
@@ -12,6 +12,8 @@ services:
     environment:
       - SPRING_CONFIG_ADDITIONAL_LOCATION=/
       - SPRING_PROFILES_ACTIVE=ft
+      - TEST_MOCKSERVER_HOST=${TEST_MOCKSERVER_HOST}
+      - TEST_COMPONENTS_REGISTRY_HOST=${TEST_COMPONENTS_REGISTRY_HOST}
 
   mockserver:
     container_name: release-management-service-ft-mockserver
@@ -33,13 +35,13 @@ services:
       - ./../../test-common/src/main/components-registry:/components-registry
 
   teamcity:
-    image: ${DOCKER_REGISTRY}/jetbrains/teamcity-server:${TEAMCITY_VERSION}
+    image: ${DOCKER_REGISTRY}/jetbrains/teamcity-server:${TEAMCITY_2022_IMAGE_TAG}
     container_name: release-management-service-ft-teamcity
     ports:
       - "8111:8111"
     volumes:
-      - ./../build/teamcity-server/datadir:/data/teamcity_server/datadir
-      - ./../build/teamcity-server/logs:/opt/teamcity/logs
+      - ./../build/teamcity-server-2022/datadir:/data/teamcity_server/datadir
+      - ./../build/teamcity-server-2022/logs:/opt/teamcity/logs
     healthcheck:
       test: curl -u admin:admin -f teamcity:8111/app/rest/server >/dev/null || exit 1
       interval: 30s
@@ -47,7 +49,7 @@ services:
       retries: 5
 
   teamcity-agent:
-    image: ${DOCKER_REGISTRY}/jetbrains/teamcity-agent:${TEAMCITY_VERSION}-linux-sudo
+    image: ${DOCKER_REGISTRY}/jetbrains/teamcity-agent:${TEAMCITY_2022_IMAGE_TAG}-linux-sudo
     container_name: release-management-service-ft-teamcity-agent
     privileged: true
     volumes:

--- a/ft/src/ft/kotlin/org/octopusden/octopus/releasemanagementservice/ActuatorTest.kt
+++ b/ft/src/ft/kotlin/org/octopusden/octopus/releasemanagementservice/ActuatorTest.kt
@@ -13,12 +13,14 @@ class ActuatorTest : BaseActuatorTest(), BaseReleaseManagementServiceFuncTest {
     override fun getServiceInfo(): ServiceInfoDTO = client.getServiceInfo()
 
     companion object {
+        private val hostReleaseManagement = System.getProperty("test.release-management-host")
+            ?: throw Exception("System property 'test.release-management-host' must be defined")
         @JvmStatic
         private val mapper = jacksonObjectMapper()
         @JvmStatic
         private val client =
             ClassicReleaseManagementServiceClient(object : ReleaseManagementServiceClientParametersProvider {
-                override fun getApiUrl() = "http://localhost:8080"
+                override fun getApiUrl() = "http://$hostReleaseManagement"
                 override fun getTimeRetryInMillis() = 180000
             })
     }

--- a/ft/src/ft/kotlin/org/octopusden/octopus/releasemanagementservice/TestUtil.kt
+++ b/ft/src/ft/kotlin/org/octopusden/octopus/releasemanagementservice/TestUtil.kt
@@ -6,20 +6,23 @@ import org.octopusden.octopus.releasemanagementservice.client.impl.ReleaseManage
 
 class TestUtil private constructor() {
     companion object {
+        private val hostReleaseManagement = System.getProperty("test.release-management-host")
+            ?: throw Exception("System property 'test.release-management-host' must be defined")
+
         @JvmStatic
         val mapper = jacksonObjectMapper()
 
         @JvmStatic
         val client =
             ClassicReleaseManagementServiceClient(object : ReleaseManagementServiceClientParametersProvider {
-                override fun getApiUrl() = "http://localhost:8080"
+                override fun getApiUrl() = "http://$hostReleaseManagement"
                 override fun getTimeRetryInMillis() = 180000
             })
 
         @JvmStatic
         fun executeAutomation(command: String, vararg options: String) =
             org.octopusden.octopus.automation.releasemanagement.main(
-                arrayOf("--url=http://localhost:8080", command, *options)
+                arrayOf("--url=http://$hostReleaseManagement", command, *options)
             )
     }
 }

--- a/ft/src/ft/kotlin/org/octopusden/octopus/releasemanagementservice/TriggerTest.kt
+++ b/ft/src/ft/kotlin/org/octopusden/octopus/releasemanagementservice/TriggerTest.kt
@@ -115,7 +115,7 @@ class TriggerTest {
                                 properties = listOf(
                                     TeamcityProperty(
                                         "release.management.build.trigger.service.url",
-                                        RELEASE_MANAGEMENT_SERVICE_URL
+                                        releaseManagementServiceUrl
                                     ),
                                     TeamcityProperty("release.management.build.trigger.selections", triggerSelector),
                                     TeamcityProperty("release.management.build.trigger.quiet.period", quietPeriod)
@@ -131,8 +131,8 @@ class TriggerTest {
     private fun readBuilds(buildTypeId: String): HttpResponse<String> {
         return httpClient.send(
             HttpRequest.newBuilder()
-                .uri(URI("${TEAMCITY_API_URL}/builds?locator=buildType:(id:${buildTypeId})"))
-                .header("Origin", TEAMCITY_URL)
+                .uri(URI("${teamcityApiUrl}/builds?locator=buildType:(id:${buildTypeId})"))
+                .header("Origin", teamcityUrl)
                 .header("Authorization", TEAMCITY_AUTHORIZATION)
                 .header("Accept", "application/json")
                 .method("GET", HttpRequest.BodyPublishers.noBody())
@@ -142,14 +142,18 @@ class TriggerTest {
     }
 
     companion object {
+        private val hostTeamcity2022 = System.getProperty("test.teamcity-2022-host")
+            ?: throw Exception("System property 'test.teamcity-2022-host' must be defined")
+        private val hostReleaseManagement = System.getProperty("test.release-management-host-for-teamcity")
+            ?: throw Exception("System property 'test.release-management-host-for-teamcity' must be defined")
+        val releaseManagementServiceUrl = "http://$hostReleaseManagement"
+        val teamcityUrl = "http://$hostTeamcity2022"
+        val teamcityApiUrl = "$teamcityUrl/app/rest/2018.1"
         const val DEFAULT_TEAMCITY_TRIGGER_POLLING_INTERVAL = 60000L
-        const val RELEASE_MANAGEMENT_SERVICE_URL = "http://release-management-service:8080"
-        const val TEAMCITY_URL = "http://localhost:8111"
-        const val TEAMCITY_API_URL = "${TEAMCITY_URL}/app/rest/2018.1"
         const val TEAMCITY_AUTHORIZATION = "Basic YWRtaW46YWRtaW4="
 
         private val teamcityClient = TeamcityClassicClient(object : ClientParametersProvider {
-            override fun getApiUrl() = TEAMCITY_URL
+            override fun getApiUrl() = teamcityUrl
             override fun getAuth() = StandardBasicCredCredentialProvider("admin", "admin")
         })
 
@@ -161,8 +165,8 @@ class TriggerTest {
             with( //TODO: enhance TeamcityClient (support agents)
                 httpClient.send(
                     HttpRequest.newBuilder()
-                        .uri(URI("${TEAMCITY_API_URL}/agents/name:test-agent/authorized"))
-                        .header("Origin", TEAMCITY_URL)
+                        .uri(URI("${teamcityApiUrl}/agents/name:test-agent/authorized"))
+                        .header("Origin", teamcityUrl)
                         .header("Authorization", TEAMCITY_AUTHORIZATION)
                         .header("Content-Type", "text/plain")
                         .method("PUT", HttpRequest.BodyPublishers.ofString("true"))

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,3 @@
-version=2.0-SNAPSHOT
 kotlin.version=1.9.22
 spring-boot.version=3.2.2
 spring-cloud.version=2023.0.0
@@ -14,6 +13,15 @@ fugue.version=6.1.2
 glassfish-jersey.version=2.27
 mockito-kotlin.version=5.4.0
 jackson-dataformat-yaml.version=2.19.1
+octopus-oc-template.version=2.0.4
 
-docker.registry=
-octopus.github.docker.registry=
+teamcity-2022.image-tag=2022.04.7
+
+test.platform=docker
+docker.registry=docker.io
+octopus.github.docker.registry=ghcr.io
+okd.active-deadline-seconds=1800
+okd.project=
+okd.cluster-domain=
+okd.web-console-url=
+okd.service-account-anyuid=teamcity

--- a/okd/components-registry.yaml
+++ b/okd/components-registry.yaml
@@ -1,0 +1,117 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: components-registry-template
+objects:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: ${DEPLOYMENT_PREFIX}-components-registry-config-data
+    data:
+      Aggregator.groovy: |-
+        ${AGGREGATOR_GROOVY_CONTENT}
+      Defaults.groovy: |-
+        ${DEFAULTS_GROOVY_CONTENT}
+      TestComponents.groovy: |-
+        ${TEST_COMPONENTS_GROOVY_CONTENT}
+      application-ft.yaml: |-
+        ${APPLICATION_FT_CONTENT}
+  - apiVersion: v1
+    kind: Pod
+    metadata:
+      name: ${DEPLOYMENT_PREFIX}-comp-reg
+      labels:
+        app.kubernetes.io/name: ${DEPLOYMENT_PREFIX}-comp-reg
+    spec:
+      restartPolicy: Never
+      activeDeadlineSeconds: ${{ACTIVE_DEADLINE_SECONDS}}
+      containers:
+        - name: comp-reg
+          image: ${DOCKER_REGISTRY}/octopusden/components-registry-service:${COMPONENTS_REGISTRY_SERVICE_VERSION}
+          ports:
+            - containerPort: 4567
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 4567
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          env:
+            - name: SPRING_CONFIG_ADDITIONAL_LOCATION
+              value: "/"
+            - name: SPRING_PROFILES_ACTIVE
+              value: "ft"
+            - name: SPRING_CLOUD_CONFIG_ENABLED
+              value: "false"
+          volumeMounts:
+            - name: components-registry-dir
+              mountPath: /components-registry
+              readOnly: true
+            - name: application-ft
+              mountPath: /application-ft.yaml
+              subPath: application-ft.yaml
+              readOnly: true
+      volumes:
+        - name: components-registry-dir
+          configMap:
+            name: ${DEPLOYMENT_PREFIX}-components-registry-config-data
+            items:
+              - key: Aggregator.groovy
+                path: Aggregator.groovy
+              - key: Defaults.groovy
+                path: Defaults.groovy
+              - key: TestComponents.groovy
+                path: TestComponents.groovy
+        - name: application-ft
+          configMap:
+            name: ${DEPLOYMENT_PREFIX}-components-registry-config-data
+            items:
+              - key: application-ft.yaml
+                path: application-ft.yaml
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: ${DEPLOYMENT_PREFIX}-comp-reg-service
+    spec:
+      ports:
+        - port: 4567
+          protocol: TCP
+          targetPort: 4567
+      selector:
+        app.kubernetes.io/name: ${DEPLOYMENT_PREFIX}-comp-reg
+  - apiVersion: route.openshift.io/v1
+    kind: Route
+    metadata:
+      name: ${DEPLOYMENT_PREFIX}-comp-reg-route
+    spec:
+      port:
+        targetPort: 4567
+      to:
+        kind: Service
+        name: ${DEPLOYMENT_PREFIX}-comp-reg-service
+parameters:
+  - description: Unique deployment prefix
+    name: DEPLOYMENT_PREFIX
+    required: true
+  - description: Active deadline seconds
+    name: ACTIVE_DEADLINE_SECONDS
+    required: true
+  - description: Docker registry
+    name: DOCKER_REGISTRY
+    required: true
+  - description: Components registry service version
+    name: COMPONENTS_REGISTRY_SERVICE_VERSION
+    required: true
+  - description: Aggregator.groovy content
+    name: AGGREGATOR_GROOVY_CONTENT
+    required: true
+  - description: Defaults.groovy content
+    name: DEFAULTS_GROOVY_CONTENT
+    required: true
+  - description: TestComponents.groovy content
+    name: TEST_COMPONENTS_GROOVY_CONTENT
+    required: true
+  - description: application-ft.yaml content
+    name: APPLICATION_FT_CONTENT
+    required: true

--- a/okd/mockserver.yaml
+++ b/okd/mockserver.yaml
@@ -1,0 +1,54 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: mockserver-template
+objects:
+  - apiVersion: v1
+    kind: Pod
+    metadata:
+      name: ${DEPLOYMENT_PREFIX}-mockserver
+      labels:
+        app.kubernetes.io/name: ${DEPLOYMENT_PREFIX}-mockserver
+    spec:
+      restartPolicy: Never
+      activeDeadlineSeconds: ${{ACTIVE_DEADLINE_SECONDS}}
+      containers:
+        - name: mockserver
+          image: ${DOCKER_REGISTRY}/mockserver/mockserver:mockserver-${MOCK_SERVER_VERSION}
+          ports:
+            - containerPort: 1080
+              protocol: TCP
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: ${DEPLOYMENT_PREFIX}-mockserver-service
+    spec:
+      ports:
+        - port: 1080
+          protocol: TCP
+          targetPort: 1080
+      selector:
+        app.kubernetes.io/name: ${DEPLOYMENT_PREFIX}-mockserver
+  - apiVersion: route.openshift.io/v1
+    kind: Route
+    metadata:
+      name: ${DEPLOYMENT_PREFIX}-mockserver-route
+    spec:
+      port:
+        targetPort: 1080
+      to:
+        kind: Service
+        name: ${DEPLOYMENT_PREFIX}-mockserver-service
+parameters:
+  - description: Unique deployment prefix
+    name: DEPLOYMENT_PREFIX
+    required: true
+  - description: Active deadline seconds
+    name: ACTIVE_DEADLINE_SECONDS
+    required: true
+  - description: Docker registry
+    name: DOCKER_REGISTRY
+    required: true
+  - description: Mockserver version
+    name: MOCK_SERVER_VERSION
+    required: true

--- a/okd/release-management.yaml
+++ b/okd/release-management.yaml
@@ -1,0 +1,115 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: release-management-template
+objects:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: ${DEPLOYMENT_PREFIX}-release-management-config-data
+    data:
+      application-ft.yml: |-
+        ${APPLICATION_FT_CONTENT}
+      bootstrap-ft.yml: |-
+        ${BOOTSTRAP_FT_CONTENT}
+  - apiVersion: v1
+    kind: Pod
+    metadata:
+      name: ${DEPLOYMENT_PREFIX}-rm
+      labels:
+        app.kubernetes.io/name: ${DEPLOYMENT_PREFIX}-rm
+    spec:
+      restartPolicy: Never
+      activeDeadlineSeconds: ${{ACTIVE_DEADLINE_SECONDS}}
+      containers:
+        - name: rm
+          image: ${OCTOPUS_GITHUB_DOCKER_REGISTRY}/octopusden/release-management-service:${RELEASE_MANAGEMENT_SERVICE_VERSION}
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          env:
+            - name: SPRING_CONFIG_ADDITIONAL_LOCATION
+              value: "/"
+            - name: SPRING_PROFILES_ACTIVE
+              value: "ft"
+            - name: TEST_MOCKSERVER_HOST
+              value: ${TEST_MOCKSERVER_HOST}
+            - name: TEST_COMPONENTS_REGISTRY_HOST
+              value: ${TEST_COMPONENTS_REGISTRY_HOST}
+          volumeMounts:
+            - name: application-ft
+              mountPath: /application-ft.yml
+              subPath: application-ft.yml
+              readOnly: true
+            - name: bootstrap-ft
+              mountPath: /bootstrap-ft.yml
+              subPath: bootstrap-ft.yml
+              readOnly: true
+      volumes:
+        - name: application-ft
+          configMap:
+            name: ${DEPLOYMENT_PREFIX}-release-management-config-data
+            items:
+              - key: application-ft.yml
+                path: application-ft.yml
+        - name: bootstrap-ft
+          configMap:
+            name: ${DEPLOYMENT_PREFIX}-release-management-config-data
+            items:
+              - key: bootstrap-ft.yml
+                path: bootstrap-ft.yml
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: ${DEPLOYMENT_PREFIX}-rm-service
+    spec:
+      ports:
+        - port: 8080
+          protocol: TCP
+          targetPort: 8080
+      selector:
+        app.kubernetes.io/name: ${DEPLOYMENT_PREFIX}-rm
+  - apiVersion: route.openshift.io/v1
+    kind: Route
+    metadata:
+      name: ${DEPLOYMENT_PREFIX}-rm-route
+    spec:
+      port:
+        targetPort: 8080
+      to:
+        kind: Service
+        name: ${DEPLOYMENT_PREFIX}-rm-service
+parameters:
+  - description: Unique deployment prefix
+    name: DEPLOYMENT_PREFIX
+    required: true
+  - description: Active deadline seconds
+    name: ACTIVE_DEADLINE_SECONDS
+    required: true
+  - description: Docker registry
+    name: DOCKER_REGISTRY
+    required: true
+  - description: Release management service version
+    name: RELEASE_MANAGEMENT_SERVICE_VERSION
+    required: true
+  - description: Octopus github docker registry
+    name: OCTOPUS_GITHUB_DOCKER_REGISTRY
+    required: true
+  - description: Test mockserver host
+    name: TEST_MOCKSERVER_HOST
+    required: true
+  - description: Test components registry host
+    name: TEST_COMPONENTS_REGISTRY_HOST
+    required: true
+  - description: application-ft.yml content
+    name: APPLICATION_FT_CONTENT
+    required: true
+  - description: bootstrap-ft.yml content
+    name: BOOTSTRAP_FT_CONTENT
+    required: true

--- a/okd/teamcity-agent.yaml
+++ b/okd/teamcity-agent.yaml
@@ -1,0 +1,82 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: teamcity-agent-template
+objects:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: ${DEPLOYMENT_PREFIX}-teamcity-agent-config-data
+    data:
+      buildAgent.properties: |-
+        ${BUILD_AGENT_PROPERTIES_CONTENT}
+  - apiVersion: v1
+    kind: Pod
+    metadata:
+      name: ${DEPLOYMENT_PREFIX}-tc${TEAMCITY_ID}-agent
+      labels:
+        app.kubernetes.io/name: ${DEPLOYMENT_PREFIX}-tc${TEAMCITY_ID}-agent
+    spec:
+      restartPolicy: Never
+      activeDeadlineSeconds: ${{ACTIVE_DEADLINE_SECONDS}}
+      serviceAccountName: ${SERVICE_ACCOUNT_ANYUID}
+      securityContext:
+        runAsUser: 0
+      initContainers:
+        - name: update-buildagent-properties
+          image: public.ecr.aws/docker/library/busybox:1.37
+          env:
+            - name: TEAMCITY_SERVER_HOST
+              value: ${TEAMCITY_SERVER_HOST}
+          command: [ "/bin/sh","-c" ]
+          args:
+            - |
+              set -eu
+              sed -E "s#^serverUrl=.*#serverUrl=http\://${TEAMCITY_SERVER_HOST}#" \
+                /in/buildAgent.properties > /conf/buildAgent.properties
+          volumeMounts:
+            - name: build-agent-properties
+              mountPath: /in
+              readOnly: true
+            - name: build-agent-properties-updated
+              mountPath: /conf
+      containers:
+        - name: tc${TEAMCITY_ID}-agent
+          image: ${DOCKER_REGISTRY}/jetbrains/teamcity-agent:${TEAMCITY_IMAGE_TAG}-linux-sudo
+          volumeMounts:
+            - name: build-agent-properties-updated
+              mountPath: /data/teamcity_agent/conf
+      volumes:
+        - name: build-agent-properties
+          configMap:
+            name: ${DEPLOYMENT_PREFIX}-teamcity-agent-config-data
+            items:
+              - key: buildAgent.properties
+                path: buildAgent.properties
+        - name: build-agent-properties-updated
+          emptyDir: {}
+parameters:
+  - description: Unique deployment prefix
+    name: DEPLOYMENT_PREFIX
+    required: true
+  - description: Active deadline seconds
+    name: ACTIVE_DEADLINE_SECONDS
+    required: true
+  - description: Docker registry
+    name: DOCKER_REGISTRY
+    required: true
+  - description: Tag of TeamCity image
+    name: TEAMCITY_IMAGE_TAG
+    required: true
+  - description: Service account name with SCC - anyuid
+    name: SERVICE_ACCOUNT_ANYUID
+    required: true
+  - description: TeamCity instance identifier
+    name: TEAMCITY_ID
+    required: true
+  - description: TeamCity server URL
+    name: TEAMCITY_SERVER_HOST
+    required: true
+  - description: buildAgent.properties content
+    name: BUILD_AGENT_PROPERTIES_CONTENT
+    required: true

--- a/okd/teamcity-pvc.yaml
+++ b/okd/teamcity-pvc.yaml
@@ -1,0 +1,23 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: teamcity-pvc-template
+objects:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: ${DEPLOYMENT_PREFIX}-teamcity${TEAMCITY_ID}-datadir
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 1Gi
+      volumeMode: Filesystem
+parameters:
+  - description: Unique deployment prefix
+    name: DEPLOYMENT_PREFIX
+    required: true
+  - description: TeamCity instance identifier
+    name: TEAMCITY_ID
+    required: true

--- a/okd/teamcity-uploader.yaml
+++ b/okd/teamcity-uploader.yaml
@@ -1,0 +1,67 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: teamcity-uploader-template
+objects:
+  - apiVersion: v1
+    kind: Pod
+    metadata:
+      name: ${DEPLOYMENT_PREFIX}-teamcity${TEAMCITY_ID}-uploader
+      labels:
+        app.kubernetes.io/name: ${DEPLOYMENT_PREFIX}-teamcity${TEAMCITY_ID}-uploader
+    spec:
+      restartPolicy: Never
+      activeDeadlineSeconds: ${{ACTIVE_DEADLINE_SECONDS}}
+      serviceAccountName: ${SERVICE_ACCOUNT_ANYUID}
+      securityContext:
+        runAsUser: 0
+      volumes:
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: ${DEPLOYMENT_PREFIX}-teamcity${TEAMCITY_ID}-datadir
+        - name: seed
+          emptyDir: { }
+      containers:
+        - name: uploader
+          image: public.ecr.aws/docker/library/busybox:1.37
+          command: ["sh","-c"]
+          args:
+            - |
+              mkdir -p /seed /data/teamcity_server/datadir /opt/teamcity/logs /data/teamcity_server/datadir/plugins/.tools
+              echo "Waiting for seed.zip..."
+              until [ -f /seed/seed.zip ]; do
+                sleep 1
+              done
+              until unzip -t /seed/seed.zip >/dev/null 2>&1; do
+                sleep 1
+              done
+              echo "Unzipping..."
+              mkdir -p /seed/unpacked
+              unzip -o /seed/seed.zip -d /seed/unpacked
+              if [ -d /seed/unpacked/datadir ]; then
+                echo "Copying datadir -> /data/teamcity_server/datadir"
+                cp -a /seed/unpacked/datadir/. /data/teamcity_server/datadir/
+              else
+                echo "!! /seed/unpacked/datadir not found"
+              fi
+              echo "Cleanup..."
+              rm -rf /seed/*
+              echo ">> Done, exiting."
+              exit 0
+          volumeMounts:
+            - name: datadir
+              mountPath: /data/teamcity_server/datadir
+            - name: seed
+              mountPath: /seed
+parameters:
+  - name: DEPLOYMENT_PREFIX
+    required: true
+  - description: Active deadline seconds
+    name: ACTIVE_DEADLINE_SECONDS
+    required: true
+  - description: Service account name with SCC - anyuid
+    name: SERVICE_ACCOUNT_ANYUID
+    required: true
+  - description: TeamCity instance identifier
+    name: TEAMCITY_ID
+    required: true

--- a/okd/teamcity.yaml
+++ b/okd/teamcity.yaml
@@ -1,0 +1,76 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: teamcity-template
+objects:
+  - apiVersion: v1
+    kind: Pod
+    metadata:
+      name: ${DEPLOYMENT_PREFIX}-teamcity${TEAMCITY_ID}
+      labels:
+        app.kubernetes.io/name: ${DEPLOYMENT_PREFIX}-teamcity${TEAMCITY_ID}
+    spec:
+      restartPolicy: Never
+      activeDeadlineSeconds: ${{ACTIVE_DEADLINE_SECONDS}}
+      serviceAccountName: ${SERVICE_ACCOUNT_ANYUID}
+      securityContext:
+        runAsUser: 0
+      volumes:
+        - name: teamcity${TEAMCITY_ID}-data
+          persistentVolumeClaim:
+            claimName: ${DEPLOYMENT_PREFIX}-teamcity${TEAMCITY_ID}-datadir
+      containers:
+        - name: teamcity${TEAMCITY_ID}
+          image: ${DOCKER_REGISTRY}/jetbrains/teamcity-server:${TEAMCITY_IMAGE_TAG}
+          ports:
+            - containerPort: 8111
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /login.html
+              port: 8111
+            initialDelaySeconds: 60
+            periodSeconds: 10
+          volumeMounts:
+            - name: teamcity${TEAMCITY_ID}-data
+              mountPath: /data/teamcity_server/datadir
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: ${DEPLOYMENT_PREFIX}-teamcity${TEAMCITY_ID}-service
+    spec:
+      ports:
+        - port: 8111
+          protocol: TCP
+          targetPort: 8111
+      selector:
+        app.kubernetes.io/name: ${DEPLOYMENT_PREFIX}-teamcity${TEAMCITY_ID}
+  - apiVersion: route.openshift.io/v1
+    kind: Route
+    metadata:
+      name: ${DEPLOYMENT_PREFIX}-teamcity${TEAMCITY_ID}-route
+    spec:
+      port:
+        targetPort: 8111
+      to:
+        kind: Service
+        name: ${DEPLOYMENT_PREFIX}-teamcity${TEAMCITY_ID}-service
+parameters:
+  - description: Unique deployment prefix
+    name: DEPLOYMENT_PREFIX
+    required: true
+  - description: Active deadline seconds
+    name: ACTIVE_DEADLINE_SECONDS
+    required: true
+  - description: Docker registry
+    name: DOCKER_REGISTRY
+    required: true
+  - description: Tag of TeamCity image
+    name: TEAMCITY_IMAGE_TAG
+    required: true
+  - description: Service account name with SCC - anyuid
+    name: SERVICE_ACCOUNT_ANYUID
+    required: true
+  - description: TeamCity instance identifier
+    name: TEAMCITY_ID
+    required: true

--- a/server/src/test/resources/application-test.yml
+++ b/server/src/test/resources/application-test.yml
@@ -1,8 +1,8 @@
 releng:
-  url: http://localhost:1080
+  url: http://${test.mockserver-host}
 
 jira1:
-  host: http://localhost:1080
+  host: http://${test.mockserver-host}
   username: admin
   password: admin
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,6 +10,7 @@ pluginManagement {
         id("io.github.gradle-nexus.publish-plugin") version "1.1.0" apply false
         id("io.github.rodm.teamcity-server") version (extra["rodm-teamcity-plugin.version"] as String)
         id("com.github.johnrengelman.shadow") version ("8.1.1")
+        id("org.octopusden.octopus.oc-template") version (extra["octopus-oc-template.version"] as String)
     }
     repositories {
         gradlePluginPortal()


### PR DESCRIPTION
The following okd parameters have also been created:
```
okd.active-deadline-seconds=1800
okd.project=
okd.cluster-domain=
okd.web-console-url=
okd.service-account-anyuid=teamcity
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Run functional tests on Docker or OpenShift (OKD) with new OKD templates, docker-compose updates, TeamCity 2022 support, automated plugin deployment and data seeding, and environment-driven endpoints for services.
  * Test runner now accepts a testPlatform choice (docker or okd) and enforces platform-specific configuration.

* **Chores**
  * Dynamic default snapshot versioning when unspecified.
  * Stricter property validation and new required CI/OKD properties; updated default CI/Docker image and registry settings.
* **Bug Fixes**
  * Improved test data migration and test environment wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->