### PR TITLE
Parameterization of the client timeout

### DIFF
--- a/automation/src/main/kotlin/org/octopusden/octopus/automation/releasemanagement/command/Command.kt
+++ b/automation/src/main/kotlin/org/octopusden/octopus/automation/releasemanagement/command/Command.kt
@@ -21,6 +21,8 @@ class Command : CliktCommand(name = "") {
         val client = ClassicReleaseManagementServiceClient(object : ReleaseManagementServiceClientParametersProvider {
             override fun getApiUrl() = url
             override fun getTimeRetryInMillis() = 180000
+            override fun getConnectTimoutInMillis() = 30000
+            override fun getReadTimoutInMillis() = 90000
         })
 
         context[LOG] = log

--- a/client/src/main/kotlin/org/octopusden/octopus/releasemanagementservice/client/impl/ClassicReleaseManagementServiceClient.kt
+++ b/client/src/main/kotlin/org/octopusden/octopus/releasemanagementservice/client/impl/ClassicReleaseManagementServiceClient.kt
@@ -27,7 +27,13 @@ class ClassicReleaseManagementServiceClient(
     private val mapper: ObjectMapper
 ) : ReleaseManagementServiceClient {
     private var client =
-        createClient(apiParametersProvider.getApiUrl(), mapper, apiParametersProvider.getTimeRetryInMillis())
+        createClient(
+            apiParametersProvider.getApiUrl(),
+            mapper,
+            apiParametersProvider.getTimeRetryInMillis(),
+            apiParametersProvider.getConnectTimoutInMillis(),
+            apiParametersProvider.getReadTimoutInMillis()
+        )
 
     constructor(apiParametersProvider: ReleaseManagementServiceClientParametersProvider) : this(
         apiParametersProvider,
@@ -49,8 +55,14 @@ class ClassicReleaseManagementServiceClient(
     override fun createMandatoryUpdate(dryRun: Boolean, dto: MandatoryUpdateDTO): MandatoryUpdateResponseDTO =
         client.createMandatoryUpdate(dryRun, dto)
 
-    fun setUrl(apiUrl: String, timeRetryInMillis: Int) {
-        client = createClient(apiUrl, mapper, timeRetryInMillis)
+    fun setUrl(apiUrl: String, timeRetryInMillis: Int, connectTimeoutInMillis: Int, readTimeoutInMillis: Int) {
+        client = createClient(
+            apiUrl,
+            mapper,
+            timeRetryInMillis,
+            connectTimeoutInMillis,
+            readTimeoutInMillis
+        )
     }
 
     override fun getServiceInfo(): ServiceInfoDTO = client.getServiceInfo()
@@ -63,11 +75,13 @@ class ClassicReleaseManagementServiceClient(
         private fun createClient(
             apiUrl: String,
             objectMapper: ObjectMapper,
-            timeRetryInMillis: Int
+            timeRetryInMillis: Int,
+            connectTimeoutInMillis: Int,
+            readTimeoutInMillis: Int
         ): ReleaseManagementServiceClient {
             return Feign.builder()
                 .client(ApacheHttpClient())
-                .options(Request.Options(30, TimeUnit.SECONDS, 30, TimeUnit.SECONDS, true))
+                .options(Request.Options(connectTimeoutInMillis.toLong(), TimeUnit.MILLISECONDS, readTimeoutInMillis.toLong(), TimeUnit.MILLISECONDS, true))
                 .encoder(JacksonEncoder(objectMapper))
                 .decoder(JacksonDecoder(objectMapper))
                 .errorDecoder(ReleaseManagementServiceErrorDecoder(objectMapper))

--- a/client/src/main/kotlin/org/octopusden/octopus/releasemanagementservice/client/impl/ReleaseManagementServiceClientParametersProvider.kt
+++ b/client/src/main/kotlin/org/octopusden/octopus/releasemanagementservice/client/impl/ReleaseManagementServiceClientParametersProvider.kt
@@ -3,4 +3,6 @@ package org.octopusden.octopus.releasemanagementservice.client.impl
 interface ReleaseManagementServiceClientParametersProvider {
     fun getApiUrl(): String
     fun getTimeRetryInMillis(): Int
+    fun getConnectTimoutInMillis(): Int
+    fun getReadTimoutInMillis(): Int
 }

--- a/ft/src/ft/kotlin/org/octopusden/octopus/releasemanagementservice/ActuatorTest.kt
+++ b/ft/src/ft/kotlin/org/octopusden/octopus/releasemanagementservice/ActuatorTest.kt
@@ -22,6 +22,8 @@ class ActuatorTest : BaseActuatorTest(), BaseReleaseManagementServiceFuncTest {
             ClassicReleaseManagementServiceClient(object : ReleaseManagementServiceClientParametersProvider {
                 override fun getApiUrl() = "http://$hostReleaseManagement"
                 override fun getTimeRetryInMillis() = 180000
+                override fun getConnectTimoutInMillis() = 30000
+                override fun getReadTimoutInMillis() = 30000
             })
     }
 }

--- a/ft/src/ft/kotlin/org/octopusden/octopus/releasemanagementservice/TestUtil.kt
+++ b/ft/src/ft/kotlin/org/octopusden/octopus/releasemanagementservice/TestUtil.kt
@@ -17,6 +17,8 @@ class TestUtil private constructor() {
             ClassicReleaseManagementServiceClient(object : ReleaseManagementServiceClientParametersProvider {
                 override fun getApiUrl() = "http://$hostReleaseManagement"
                 override fun getTimeRetryInMillis() = 180000
+                override fun getConnectTimoutInMillis() = 30000
+                override fun getReadTimoutInMillis() = 30000
             })
 
         @JvmStatic

--- a/teamcity-plugin/src/main/kotlin/org/octopusden/octopus/releasemanagementservice/teamcity/plugin/ReleaseManagementBuildTriggerService.kt
+++ b/teamcity-plugin/src/main/kotlin/org/octopusden/octopus/releasemanagementservice/teamcity/plugin/ReleaseManagementBuildTriggerService.kt
@@ -169,6 +169,8 @@ class ReleaseManagementBuildTriggerService(
             ClassicReleaseManagementServiceClient(object : ReleaseManagementServiceClientParametersProvider {
                 override fun getApiUrl() = serviceUrl
                 override fun getTimeRetryInMillis() = 1000
+                override fun getConnectTimoutInMillis() = 30000
+                override fun getReadTimoutInMillis() = 30000
             })
     }
 }


### PR DESCRIPTION
The timeout for automation has also been increased. And the client is now created as follows:
```
val client = ClassicReleaseManagementServiceClient(object : ReleaseManagementServiceClientParametersProvider {
            override fun getApiUrl() = ...
            override fun getTimeRetryInMillis() = ...
            override fun getConnectTimoutInMillis() = ...
            override fun getReadTimoutInMillis() = ...
        })
```