### PR TITLE
chore: configure dependabot for org.octopusden dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Asia/Nicosia"
+    open-pull-requests-limit: 10
+    allow:
+      - dependency-name: "org.octopusden*"
+        dependency-type: "direct"
+    groups:
+      octopus-external-systems-clients:
+        patterns:
+          - "org.octopusden.octopus.octopus-external-systems-clients:*"
+      octopus-infrastructure:
+        patterns:
+          - "org.octopusden.octopus.infrastructure:*"
+      octopus-plugins:
+        patterns:
+          - "org.octopusden.octopus.oc-template"
+          - "org.octopusden.octopus.oc-template:*"
+    labels:
+      - "dependencies"
+      - "octopusden"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
       day: "monday"
       time: "06:00"
       timezone: "Asia/Nicosia"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 3
     allow:
       - dependency-name: "org.octopusden*"
         dependency-type: "direct"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,4 +24,4 @@ updates:
           - "org.octopusden.octopus.oc-template:*"
     labels:
       - "dependencies"
-      - "octopusden"
+      - "build"


### PR DESCRIPTION
## Summary
- add Dependabot config for Gradle
- allow updates only for direct dependencies in org.octopusden namespace
- group updates by component for org.octopusden.octopus.octopus-external-systems-clients and org.octopusden.octopus.infrastructure
- keep org.octopusden.octopus.oc-template plugin updates in dedicated group

## Result
- jira-client and teamcity-client are updated in one PR when updates are available
- other org.octopusden dependencies are grouped by component


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated dependency-management configuration: weekly Gradle updates (Mondays 06:00 Asia/Nicosia), up to 3 open update PRs, targets direct dependencies matching the Octopus namespace, groups updates into three Octopus package patterns, and auto-labels update PRs with "dependencies" and "build".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->