### PR TITLE
ci: align workflows with octopus-base merge contract (pre-release)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,11 @@
 name: Gradle Compile & UT
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+  workflow_call:
 
 jobs:
   run-build-and-deploy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   run-build-and-deploy:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.1.12
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@feature/common-quality-gates
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.1.12
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@feature/common-quality-gates
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
       artifact-pattern: "octopus/release-management-service/release-management-service/_VER_/release-management-service-_VER_.jar"

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -1,0 +1,49 @@
+name: Merge Gate
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  quality:
+    uses: ./.github/workflows/quality.yml
+
+  security:
+    uses: ./.github/workflows/security.yml
+
+  build:
+    uses: ./.github/workflows/build.yml
+
+  gate-merge:
+    name: gate/merge
+    if: ${{ always() }}
+    needs:
+      - quality
+      - security
+      - build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate gate results
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          results='${{ toJson(needs) }}'
+          failed="$(jq -r 'to_entries[] | select(.value.result != "success") | "\(.key): \(.value.result)"' <<<"${results}")"
+
+          {
+            echo "### Merge gate results"
+            jq -r 'to_entries[] | "- \(.key): \(.value.result)"' <<<"${results}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [[ -n "${failed}" ]]; then
+            echo "Merge gate failed:"
+            echo "${failed}"
+            exit 1
+          fi
+
+          echo "Merge gate passed."

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -11,46 +11,8 @@ permissions:
   contents: read
 
 jobs:
-  static:
-    name: quality/static
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: "21"
-      - uses: gradle/actions/setup-gradle@v3
-      - name: Run static checks
-        run: ./gradlew qualityStatic --no-daemon --stacktrace
-      - name: Upload static analysis reports
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: static-analysis-reports
-          path: |
-            **/build/reports/detekt/**
-            **/build/reports/ktlint/**
-
-  tests-coverage:
-    name: quality/tests-coverage
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: "21"
-      - uses: gradle/actions/setup-gradle@v3
-      - name: Run tests and coverage verification
-        run: ./gradlew qualityCoverage -x :release-management-service:test -x koverVerify -x koverCachedVerify --no-daemon --stacktrace
-      - name: Upload coverage reports
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-reports
-          path: |
-            **/build/reports/kover/**
-            **/build/reports/tests/**
+  quality:
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@1c60001b6508a4a9a6f904c8fac5417a3299a991
+    with:
+      java-version: "21"
+      coverage-command: ./gradlew qualityCoverage -x :release-management-service:test -x koverVerify -x koverCachedVerify --no-daemon --stacktrace

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,11 +1,11 @@
 name: Quality Gates
 
 on:
-  pull_request:
   push:
     branches:
       - main
   workflow_dispatch:
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   quality:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@1c60001b6508a4a9a6f904c8fac5417a3299a991
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@feature/common-quality-gates
     with:
       java-version: "21"
       coverage-command: ./gradlew qualityCoverage -x :release-management-service:test -x koverVerify -x koverCachedVerify --no-daemon --stacktrace

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.1.12
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@feature/common-quality-gates
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   security:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@1c60001b6508a4a9a6f904c8fac5417a3299a991
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@feature/common-quality-gates
     with:
       java-version: "21"
       # Keep dependency-check disabled until its data sources stabilize.

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -14,87 +14,11 @@ permissions:
   security-events: write
 
 jobs:
-  dependency-check:
-    name: security/dependency-check
-    # TODO: Re-enable after dependency-check stability is fixed (NVD API/source reliability).
-    if: ${{ false }}
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: "21"
-      - uses: gradle/actions/setup-gradle@v3
-      - name: Run OWASP Dependency-Check (report-only)
-        run: ./gradlew securityReport --no-daemon --stacktrace
-      - name: Upload Dependency-Check SARIF
-        if: always()
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: build/reports/dependency-check/dependency-check-report.sarif
-      - name: Upload Dependency-Check reports
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: dependency-check-reports
-          path: build/reports/dependency-check/**
-
-  codeql:
-    name: security/codeql
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@v4
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
-        with:
-          languages: java-kotlin
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
-      - name: Analyze
-        uses: github/codeql-action/analyze@v3
-        with:
-          category: "/language:java-kotlin"
-      - name: Upload CodeQL report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: codeql-sarif
-          path: results/**/*.sarif
-          if-no-files-found: warn
-
-  trivy:
-    name: security/trivy
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@v4
-      - name: Run Trivy filesystem scan (report-only)
-        continue-on-error: true
-        uses: aquasecurity/trivy-action@0.34.2
-        with:
-          version: v0.69.3
-          scan-type: fs
-          scan-ref: .
-          scanners: vuln,misconfig,secret
-          format: sarif
-          output: trivy-results.sarif
-          severity: MEDIUM,HIGH,CRITICAL
-          exit-code: "0"
-      - name: Upload Trivy SARIF
-        if: ${{ always() && hashFiles('trivy-results.sarif') != '' }}
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: trivy-results.sarif
-      - name: Upload Trivy report
-        if: ${{ always() && hashFiles('trivy-results.sarif') != '' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: trivy-sarif
-          path: trivy-results.sarif
-          if-no-files-found: warn
+  security:
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@1c60001b6508a4a9a6f904c8fac5417a3299a991
+    with:
+      java-version: "21"
+      # Keep dependency-check disabled until its data sources stabilize.
+      enable-dependency-check: false
+      codeql-continue-on-error: true
+      trivy-continue-on-error: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,13 +1,13 @@
 name: Security Reports
 
 on:
-  pull_request:
   push:
     branches:
       - main
   schedule:
     - cron: "0 3 * * *"
   workflow_dispatch:
+  workflow_call:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- switch all octopus-base reusable workflow refs in this repository to `feature/common-quality-gates`
- add `Merge Gate` as the single PR merge-contract workflow
- make local `build`, `quality`, and `security` workflows reusable via `workflow_call`
- remove direct `pull_request` triggers from local `build`, `quality`, and `security` wrappers so PR validation goes through `Merge Gate`

## Contract alignment
This follows the consumer-repository contract introduced in octopus-base PR #108:
- human-readable workflows remain in the repository: `Quality Gates`, `Security Reports`
- PR merge decision is aggregated by `Merge Gate / gate/merge`
- `build`, `quality`, and `security` are executed inside the merge gate instead of as parallel standalone PR workflows

## Context
Preliminary consumer PR before octopus-base release.

## Follow-up
After octopus-base PR #108 is merged and tagged, replace branch refs with the released tag.
Branch protection can then be updated to require only `Merge Gate / gate/merge`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated quality and security pipelines into delegated reusable workflows for simpler CI configuration
  * Updated build and release workflow references to the latest shared workflow variant
  * Added a "Merge Gate" workflow to validate and enforce gate results before merging, improving merge safety and visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->