### PR TITLE
Fix unstable Functional Test

### DIFF
--- a/buildSrc/src/main/kotlin/org/octopusden/task/MigrateMockData.kt
+++ b/buildSrc/src/main/kotlin/org/octopusden/task/MigrateMockData.kt
@@ -115,7 +115,7 @@ abstract class MigrateMockData : DefaultTask() {
 
         private val defaultParams = mapOf("descending" to listOf("false"))
         private val endpointToResponseFileName = mapOf(
-            "/rest/release-engineering/3/component/ReleaseManagementService/builds" to defaultParams + mapOf("limit" to listOf("10"))to "releng/builds.json",
+            "/rest/release-engineering/3/component/ReleaseManagementService/builds" to defaultParams + mapOf("limit" to listOf("10")) to "releng/builds.json",
             "/rest/release-engineering/3/component/ReleaseManagementService/builds" to defaultParams + mapOf("limit" to listOf("1")) to "releng/builds-limit.json",
             "/rest/release-engineering/3/component/ReleaseManagementService/builds" to defaultParams + mapOf("descending" to listOf("true")) to "releng/builds-descending.json",
             "/rest/release-engineering/3/component/ReleaseManagementService/builds" to defaultParams + mapOf("minors" to listOf("2.0")) to "releng/builds-2.0.json",

--- a/buildSrc/src/main/kotlin/org/octopusden/task/MigrateMockData.kt
+++ b/buildSrc/src/main/kotlin/org/octopusden/task/MigrateMockData.kt
@@ -27,7 +27,8 @@ abstract class MigrateMockData : DefaultTask() {
 
     @TaskAction
     fun startMockServer() {
-        mockServerClient.reset()
+        waitForMockServerReady()
+        resetWithRetry()
         endpointToResponseFileName.forEach {
             generateMockserverData(it.key.first, it.key.second, testDataDir.get() + File.separator + it.value, HttpStatusCode.OK_200.code())
         }
@@ -40,6 +41,43 @@ abstract class MigrateMockData : DefaultTask() {
             testDataDir.get() + File.separator + "jira/create-issue.json",
             HttpStatusCode.CREATED_201.code(),
             "POST"
+        )
+    }
+
+    private fun waitForMockServerReady() {
+        val deadline = System.currentTimeMillis() + READINESS_TIMEOUT
+        while (System.currentTimeMillis() < deadline) {
+            try {
+                if (mockServerClient.hasStarted()) {
+                    logger.lifecycle("MockServer at {}:{} is ready", host.get(), port.get())
+                    return
+                }
+            } catch (e: Exception) {
+                logger.debug("MockServer not ready yet: {}", e.message)
+            }
+            Thread.sleep(READINESS_POLL_INTERVAL)
+        }
+        throw RuntimeException(
+            "MockServer at ${host.get()}:${port.get()} did not become ready within ${READINESS_TIMEOUT / 1000}s"
+        )
+    }
+
+    private fun resetWithRetry() {
+        var lastException: Exception? = null
+        for (attempt in 1..RETRY_ATTEMPTS) {
+            try {
+                mockServerClient.reset()
+                return
+            } catch (e: Exception) {
+                lastException = e
+                logger.warn("MockServer reset attempt $attempt/$RETRY_ATTEMPTS failed: {}", e.message)
+                if (attempt < RETRY_ATTEMPTS) {
+                    Thread.sleep(RETRY_DELAYS[attempt - 1])
+                }
+            }
+        }
+        throw RuntimeException(
+            "MockServer reset at ${host.get()}:${port.get()} failed after $RETRY_ATTEMPTS attempts", lastException
         )
     }
 
@@ -70,6 +108,11 @@ abstract class MigrateMockData : DefaultTask() {
     }
 
     companion object {
+        private const val READINESS_POLL_INTERVAL = 5000L
+        private const val READINESS_TIMEOUT = 120000L
+        private const val RETRY_ATTEMPTS = 5
+        private val RETRY_DELAYS = longArrayOf(1000, 2000, 4000, 8000, 16000)
+
         private val defaultParams = mapOf("descending" to listOf("false"))
         private val endpointToResponseFileName = mapOf(
             "/rest/release-engineering/3/component/ReleaseManagementService/builds" to defaultParams + mapOf("limit" to listOf("10"))to "releng/builds.json",

--- a/ft/src/ft/kotlin/org/octopusden/octopus/releasemanagementservice/ActuatorTest.kt
+++ b/ft/src/ft/kotlin/org/octopusden/octopus/releasemanagementservice/ActuatorTest.kt
@@ -6,15 +6,17 @@ import org.octopusden.octopus.releasemanagementservice.client.common.dto.Service
 import org.octopusden.octopus.releasemanagementservice.client.impl.ClassicReleaseManagementServiceClient
 import org.octopusden.octopus.releasemanagementservice.client.impl.ReleaseManagementServiceClientParametersProvider
 
-class ActuatorTest : BaseActuatorTest(), BaseReleaseManagementServiceFuncTest {
-
+class ActuatorTest :
+    BaseActuatorTest(),
+    BaseReleaseManagementServiceFuncTest {
     override fun getObjectMapper(): ObjectMapper = mapper
 
     override fun getServiceInfo(): ServiceInfoDTO = client.getServiceInfo()
 
     companion object {
-        private val hostReleaseManagement = System.getProperty("test.release-management-host")
-            ?: throw Exception("System property 'test.release-management-host' must be defined")
+        private val hostReleaseManagement =
+            System.getProperty("test.release-management-host")
+                ?: throw Exception("System property 'test.release-management-host' must be defined")
 
         @JvmStatic
         private val mapper = jacksonObjectMapper()

--- a/ft/src/ft/kotlin/org/octopusden/octopus/releasemanagementservice/AutomationTest.kt
+++ b/ft/src/ft/kotlin/org/octopusden/octopus/releasemanagementservice/AutomationTest.kt
@@ -11,33 +11,44 @@ import org.octopusden.octopus.releasemanagementservice.client.common.dto.Mandato
 import java.io.File
 
 class AutomationTest : BaseReleaseManagementServiceFuncTest {
-
     override fun getObjectMapper() = TestUtil.mapper
 
     @Test
     fun testDependenciesStatus() {
         val expected = "ReleaseManagementService:1.0.1 BUILD [\n    dependency1:0.1 RC\n    dependency2:0.2 RELEASE\n]"
-        val outFile = File("").resolve("build").resolve("automation-test")
-            .resolve("testDependenciesStatus.txt").also { it.parentFile.mkdirs() }
+        val outFile =
+            File("")
+                .resolve("build")
+                .resolve("automation-test")
+                .resolve("testDependenciesStatus.txt")
+                .also { it.parentFile.mkdirs() }
         TestUtil.executeAutomation(
             DependenciesStatus.COMMAND,
             "${DependenciesStatus.COMPONENT_NAME}=ReleaseManagementService",
             "${DependenciesStatus.VERSION}=1.0.1",
-            "${DependenciesStatus.DEPENDENCIES_STATUS_FILE}=${outFile.absolutePath}"
+            "${DependenciesStatus.DEPENDENCIES_STATUS_FILE}=${outFile.absolutePath}",
         )
         Assertions.assertEquals(expected, outFile.readText().replace("\r\n", "\n"))
     }
 
     @Test
     fun testMandatoryUpdate() {
-        val outFile = File("").resolve("build").resolve("automation-test")
-            .resolve("testMandatoryUpdate.json").also { it.parentFile.mkdirs() }
-        val expected = getObjectMapper()
-            .registerKotlinModule()
-            .enable(SerializationFeature.INDENT_OUTPUT)
-            .writeValueAsString(
-                loadObject("../test-data/releng/create-mandatory-update-3.json", object : TypeReference<MandatoryUpdateResponseDTO>() {})
-            )
+        val outFile =
+            File("")
+                .resolve("build")
+                .resolve("automation-test")
+                .resolve("testMandatoryUpdate.json")
+                .also { it.parentFile.mkdirs() }
+        val expected =
+            getObjectMapper()
+                .registerKotlinModule()
+                .enable(SerializationFeature.INDENT_OUTPUT)
+                .writeValueAsString(
+                    loadObject(
+                        "../test-data/releng/create-mandatory-update-3.json",
+                        object : TypeReference<MandatoryUpdateResponseDTO>() {},
+                    ),
+                )
         TestUtil.executeAutomation(
             MandatoryUpdate.COMMAND,
             "${MandatoryUpdate.COMPONENT}=dependency-component-first",
@@ -49,7 +60,7 @@ class AutomationTest : BaseReleaseManagementServiceFuncTest {
             "${MandatoryUpdate.DRY_RUN}=false",
             "${MandatoryUpdate.IS_FULL_MATCH_SYSTEMS}=true",
             "${MandatoryUpdate.ACTIVE_LINE_PERIOD}=180",
-            "${MandatoryUpdate.OUTPUT_FILE}=${outFile.absolutePath}"
+            "${MandatoryUpdate.OUTPUT_FILE}=${outFile.absolutePath}",
         )
         Assertions.assertEquals(expected, outFile.readText())
     }

--- a/ft/src/ft/kotlin/org/octopusden/octopus/releasemanagementservice/BuildControllerTest.kt
+++ b/ft/src/ft/kotlin/org/octopusden/octopus/releasemanagementservice/BuildControllerTest.kt
@@ -5,16 +5,25 @@ import org.octopusden.octopus.releasemanagementservice.client.common.dto.ErrorRe
 import org.octopusden.octopus.releasemanagementservice.client.common.dto.ReleaseManagementServiceErrorCode
 import org.octopusden.octopus.releasemanagementservice.client.common.exception.NotFoundException
 
-class BuildControllerTest : BaseBuildControllerTest(), BaseReleaseManagementServiceFuncTest {
-
+class BuildControllerTest :
+    BaseBuildControllerTest(),
+    BaseReleaseManagementServiceFuncTest {
     override fun getObjectMapper() = TestUtil.mapper
 
-    override fun getBuilds(component: String, params: Map<String, Any>) =
-        TestUtil.client.getBuilds(component, TestUtil.mapper.convertValue(params, BuildFilterDTO::class.java))
+    override fun getBuilds(
+        component: String,
+        params: Map<String, Any>,
+    ) = TestUtil.client.getBuilds(component, TestUtil.mapper.convertValue(params, BuildFilterDTO::class.java))
 
-    override fun getBuild(component: String, version: String) = TestUtil.client.getBuild(component, version)
+    override fun getBuild(
+        component: String,
+        version: String,
+    ) = TestUtil.client.getBuild(component, version)
 
-    override fun getNotExistedBuildErrorResponse(component: String, version: String) = try {
+    override fun getNotExistedBuildErrorResponse(
+        component: String,
+        version: String,
+    ) = try {
         TestUtil.client.getBuild(component, version)
         ErrorResponse(ReleaseManagementServiceErrorCode.OTHER, "Failure expected")
     } catch (e: NotFoundException) {

--- a/ft/src/ft/kotlin/org/octopusden/octopus/releasemanagementservice/SupportControllerTest.kt
+++ b/ft/src/ft/kotlin/org/octopusden/octopus/releasemanagementservice/SupportControllerTest.kt
@@ -11,10 +11,11 @@ class SupportControllerTest : BaseSupportControllerTest() {
 
     override fun getComponent(component: String) = TestUtil.client.getComponent(component)
 
-    override fun getNotExistedComponentErrorResponse(component: String) = try {
-        TestUtil.client.getComponent(component)
-        ErrorResponse(ReleaseManagementServiceErrorCode.OTHER, "Failure expected")
-    } catch (e: NotFoundException) {
-        ErrorResponse(ReleaseManagementServiceErrorCode.NOT_FOUND, e.message!!)
-    }
+    override fun getNotExistedComponentErrorResponse(component: String) =
+        try {
+            TestUtil.client.getComponent(component)
+            ErrorResponse(ReleaseManagementServiceErrorCode.OTHER, "Failure expected")
+        } catch (e: NotFoundException) {
+            ErrorResponse(ReleaseManagementServiceErrorCode.NOT_FOUND, e.message!!)
+        }
 }

--- a/ft/src/ft/kotlin/org/octopusden/octopus/releasemanagementservice/TestUtil.kt
+++ b/ft/src/ft/kotlin/org/octopusden/octopus/releasemanagementservice/TestUtil.kt
@@ -6,25 +6,33 @@ import org.octopusden.octopus.releasemanagementservice.client.impl.ReleaseManage
 
 class TestUtil private constructor() {
     companion object {
-        private val hostReleaseManagement = System.getProperty("test.release-management-host")
-            ?: throw Exception("System property 'test.release-management-host' must be defined")
+        private val hostReleaseManagement =
+            System.getProperty("test.release-management-host")
+                ?: throw Exception("System property 'test.release-management-host' must be defined")
 
         @JvmStatic
         val mapper = jacksonObjectMapper()
 
         @JvmStatic
         val client =
-            ClassicReleaseManagementServiceClient(object : ReleaseManagementServiceClientParametersProvider {
-                override fun getApiUrl() = "http://$hostReleaseManagement"
-                override fun getTimeRetryInMillis() = 180000
-                override fun getConnectTimeoutInMillis() = 30000
-                override fun getReadTimeoutInMillis() = 30000
-            })
+            ClassicReleaseManagementServiceClient(
+                object : ReleaseManagementServiceClientParametersProvider {
+                    override fun getApiUrl() = "http://$hostReleaseManagement"
+
+                    override fun getTimeRetryInMillis() = 180000
+
+                    override fun getConnectTimeoutInMillis() = 30000
+
+                    override fun getReadTimeoutInMillis() = 30000
+                },
+            )
 
         @JvmStatic
-        fun executeAutomation(command: String, vararg options: String) =
-            org.octopusden.octopus.automation.releasemanagement.main(
-                arrayOf("--url=http://$hostReleaseManagement", command, *options)
-            )
+        fun executeAutomation(
+            command: String,
+            vararg options: String,
+        ) = org.octopusden.octopus.automation.releasemanagement.main(
+            arrayOf("--url=http://$hostReleaseManagement", command, *options),
+        )
     }
 }

--- a/ft/src/ft/kotlin/org/octopusden/octopus/releasemanagementservice/TriggerTest.kt
+++ b/ft/src/ft/kotlin/org/octopusden/octopus/releasemanagementservice/TriggerTest.kt
@@ -96,13 +96,14 @@ class TriggerTest {
         var lastBody = ""
         while (System.currentTimeMillis() < deadline) {
             val response = readBuilds(buildTypeId)
+            lastBody = "status=${response.statusCode()}\n${response.body()}"
             if (response.statusCode() / 100 == 5) {
                 Thread.sleep(BUILDS_POLL_INTERVAL)
                 continue
             }
             Assertions.assertTrue(
                 response.statusCode() / 100 == 2,
-                "Unable to get builds of build type '$buildTypeId': status=${response.statusCode()}\n${response.body()}",
+                "Unable to get builds of build type '$buildTypeId': $lastBody",
             )
             lastBody = response.body()
             if (lastBody.contains("\"count\":$expectedCount,")) {

--- a/ft/src/ft/kotlin/org/octopusden/octopus/releasemanagementservice/TriggerTest.kt
+++ b/ft/src/ft/kotlin/org/octopusden/octopus/releasemanagementservice/TriggerTest.kt
@@ -74,7 +74,7 @@ class TriggerTest {
                 quietPeriod = dynamicQuietPeriod.toString(),
             )
         Thread.sleep(DEFAULT_TEAMCITY_TRIGGER_POLLING_INTERVAL)
-        with(readBuilds(buildType.id)) {
+        with(readBuildsWithRetry(buildType.id)) {
             Assertions.assertTrue(
                 statusCode() / 100 == 2,
                 "Unable to get builds of build type '${buildType.id}':\n${body()}",
@@ -96,6 +96,10 @@ class TriggerTest {
         var lastBody = ""
         while (System.currentTimeMillis() < deadline) {
             val response = readBuilds(buildTypeId)
+            if (response.statusCode() / 100 == 5) {
+                Thread.sleep(BUILDS_POLL_INTERVAL)
+                continue
+            }
             Assertions.assertTrue(
                 response.statusCode() / 100 == 2,
                 "Unable to get builds of build type '$buildTypeId': status=${response.statusCode()}\n${response.body()}",
@@ -143,6 +147,19 @@ class TriggerTest {
                     ),
             ),
         )
+
+    private fun readBuildsWithRetry(buildTypeId: String): HttpResponse<String> {
+        for (attempt in 0 until RETRY_ATTEMPTS) {
+            val response = readBuilds(buildTypeId)
+            if (response.statusCode() / 100 != 5) {
+                return response
+            }
+            if (attempt < RETRY_ATTEMPTS - 1) {
+                Thread.sleep(RETRY_DELAYS[attempt])
+            }
+        }
+        return readBuilds(buildTypeId)
+    }
 
     private fun readBuilds(buildTypeId: String): HttpResponse<String> =
         httpClient.send(

--- a/ft/src/ft/kotlin/org/octopusden/octopus/releasemanagementservice/TriggerTest.kt
+++ b/ft/src/ft/kotlin/org/octopusden/octopus/releasemanagementservice/TriggerTest.kt
@@ -1,11 +1,5 @@
 package org.octopusden.octopus.releasemanagementservice
 
-import java.io.IOException
-import java.net.URI
-import java.net.http.HttpClient
-import java.net.http.HttpRequest
-import java.net.http.HttpResponse
-import java.time.Duration
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
@@ -20,71 +14,91 @@ import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityPropert
 import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityTrigger
 import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityTriggers
 import org.octopusden.octopus.releasemanagementservice.client.common.dto.BuildStatus
+import java.io.IOException
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
 
 class TriggerTest {
     @Test
     fun test() {
-        val buildType = createBuildType(
-            name = "Trigger Test",
-            triggerSelector = """
-                - component: ReleaseManagementService
-                  status: RELEASE
-            """.trimIndent()
-        )
+        val buildType =
+            createBuildType(
+                name = "Trigger Test",
+                triggerSelector =
+                    """
+                    - component: ReleaseManagementService
+                      status: RELEASE
+                    """.trimIndent(),
+            )
         // TD-002: switch to TeamcityClient builds API once supported (see docs/TECH_DEBT.md).
         pollBuildsUntilCount(buildType.id, expectedCount = 1)
     }
 
     @Test
     fun testInReleaseBranch() {
-        val buildType = createBuildType(
-            name = "Trigger In Release Branch Test",
-            triggerSelector = """
-                - component: ReleaseManagementService
-                  status: RELEASE
-                  inReleaseBranch: true
-            """.trimIndent()
-        )
+        val buildType =
+            createBuildType(
+                name = "Trigger In Release Branch Test",
+                triggerSelector =
+                    """
+                    - component: ReleaseManagementService
+                      status: RELEASE
+                      inReleaseBranch: true
+                    """.trimIndent(),
+            )
         // TD-002: switch to TeamcityClient builds API once supported (see docs/TECH_DEBT.md).
         pollBuildsUntilCount(buildType.id, expectedCount = 1)
     }
 
     @Test
     fun testQuietPeriod() {
-        val releaseTime = TestUtil.client.getBuild("ReleaseManagementService", "2.0.1").statusHistory.getValue(BuildStatus.RELEASE)
+        val releaseTime =
+            TestUtil.client
+                .getBuild("ReleaseManagementService", "2.0.1")
+                .statusHistory
+                .getValue(BuildStatus.RELEASE)
         val diffSec = (System.currentTimeMillis() - releaseTime.time) / 1000
         val pollIntervalSec = DEFAULT_TEAMCITY_TRIGGER_POLLING_INTERVAL / 1000
         val dynamicQuietPeriod = diffSec + pollIntervalSec
-        val buildType = createBuildType(
-            name = "Test quiet period",
-            triggerSelector = """
-            - component: ReleaseManagementService
-              status: RELEASE
-        """.trimIndent(),
-            quietPeriod = dynamicQuietPeriod.toString()
-        )
+        val buildType =
+            createBuildType(
+                name = "Test quiet period",
+                triggerSelector =
+                    """
+                    - component: ReleaseManagementService
+                      status: RELEASE
+                    """.trimIndent(),
+                quietPeriod = dynamicQuietPeriod.toString(),
+            )
         Thread.sleep(DEFAULT_TEAMCITY_TRIGGER_POLLING_INTERVAL)
         with(readBuilds(buildType.id)) {
             Assertions.assertTrue(
                 statusCode() / 100 == 2,
-                "Unable to get builds of build type '${buildType.id}':\n${body()}"
+                "Unable to get builds of build type '${buildType.id}':\n${body()}",
             )
             Assertions.assertTrue(
                 body().contains("\"count\":0,"),
-                "Expected 0 builds during quiet period, but got:\n${body()}"
+                "Expected 0 builds during quiet period, but got:\n${body()}",
             )
         }
         pollBuildsUntilCount(buildType.id, expectedCount = 1, failureMessage = "Expected 1 build after quiet period elapsed")
     }
 
-    private fun pollBuildsUntilCount(buildTypeId: String, expectedCount: Int, failureMessage: String? = null) {
+    private fun pollBuildsUntilCount(
+        buildTypeId: String,
+        expectedCount: Int,
+        failureMessage: String? = null,
+    ) {
         val deadline = System.currentTimeMillis() + BUILDS_POLL_TIMEOUT
         var lastBody = ""
         while (System.currentTimeMillis() < deadline) {
             val response = readBuilds(buildTypeId)
             Assertions.assertTrue(
                 response.statusCode() / 100 == 2,
-                "Unable to get builds of build type '$buildTypeId': status=${response.statusCode()}\n${response.body()}"
+                "Unable to get builds of build type '$buildTypeId': status=${response.statusCode()}\n${response.body()}",
             )
             lastBody = response.body()
             if (lastBody.contains("\"count\":$expectedCount,")) {
@@ -93,53 +107,63 @@ class TriggerTest {
             Thread.sleep(BUILDS_POLL_INTERVAL)
         }
         Assertions.fail<Unit>(
-            "${failureMessage ?: "Number of builds of build type '$buildTypeId' is not equals to $expectedCount"}:\n$lastBody"
+            "${failureMessage ?: "Number of builds of build type '$buildTypeId' is not equals to $expectedCount"}:\n$lastBody",
         )
     }
 
-    private fun createBuildType(name: String, triggerSelector: String, quietPeriod: String = "0"): TeamcityBuildType {
-        return teamcityClient.createBuildType(
+    private fun createBuildType(
+        name: String,
+        triggerSelector: String,
+        quietPeriod: String = "0",
+    ): TeamcityBuildType =
+        teamcityClient.createBuildType(
             TeamcityCreateBuildType(
                 name = name,
                 project = TeamcityLinkProject("RDDepartment"),
-                triggers = TeamcityTriggers(
-                    triggers = listOf(
-                        TeamcityTrigger(
-                            "release-management-teamcity-build-trigger", false, TeamcityProperties(
-                                properties = listOf(
-                                    TeamcityProperty(
-                                        "release.management.build.trigger.service.url",
-                                        releaseManagementServiceUrl
+                triggers =
+                    TeamcityTriggers(
+                        triggers =
+                            listOf(
+                                TeamcityTrigger(
+                                    "release-management-teamcity-build-trigger",
+                                    false,
+                                    TeamcityProperties(
+                                        properties =
+                                            listOf(
+                                                TeamcityProperty(
+                                                    "release.management.build.trigger.service.url",
+                                                    releaseManagementServiceUrl,
+                                                ),
+                                                TeamcityProperty("release.management.build.trigger.selections", triggerSelector),
+                                                TeamcityProperty("release.management.build.trigger.quiet.period", quietPeriod),
+                                            ),
                                     ),
-                                    TeamcityProperty("release.management.build.trigger.selections", triggerSelector),
-                                    TeamcityProperty("release.management.build.trigger.quiet.period", quietPeriod)
-                                )
-                            )
-                        )
-                    )
-                )
-            )
+                                ),
+                            ),
+                    ),
+            ),
         )
-    }
 
-    private fun readBuilds(buildTypeId: String): HttpResponse<String> {
-        return httpClient.send(
-            HttpRequest.newBuilder()
-                .uri(URI("${teamcityApiUrl}/builds?locator=buildType:(id:${buildTypeId})"))
+    private fun readBuilds(buildTypeId: String): HttpResponse<String> =
+        httpClient.send(
+            HttpRequest
+                .newBuilder()
+                .uri(URI("$teamcityApiUrl/builds?locator=buildType:(id:$buildTypeId)"))
                 .header("Origin", teamcityUrl)
                 .header("Authorization", TEAMCITY_AUTHORIZATION)
                 .header("Accept", "application/json")
                 .method("GET", HttpRequest.BodyPublishers.noBody())
                 .build(),
-            HttpResponse.BodyHandlers.ofString()
+            HttpResponse.BodyHandlers.ofString(),
         )
-    }
 
     companion object {
-        private val hostTeamcity2022 = System.getProperty("test.teamcity-2022-host")
-            ?: throw Exception("System property 'test.teamcity-2022-host' must be defined")
-        private val hostReleaseManagement = System.getProperty("test.release-management-host-for-teamcity")
-            ?: throw Exception("System property 'test.release-management-host-for-teamcity' must be defined")
+        private val hostTeamcity2022 =
+            System.getProperty("test.teamcity-2022-host")
+                ?: throw Exception("System property 'test.teamcity-2022-host' must be defined")
+        private val hostReleaseManagement =
+            System.getProperty("test.release-management-host-for-teamcity")
+                ?: throw Exception("System property 'test.release-management-host-for-teamcity' must be defined")
         val releaseManagementServiceUrl = "http://$hostReleaseManagement"
         val teamcityUrl = "http://$hostTeamcity2022"
         val teamcityApiUrl = "$teamcityUrl/app/rest/2018.1"
@@ -152,25 +176,33 @@ class TriggerTest {
         private const val RETRY_ATTEMPTS = 5
         private val RETRY_DELAYS = longArrayOf(1000, 2000, 4000, 8000, 16000)
 
-        private val teamcityClient = TeamcityClassicClient(object : ClientParametersProvider {
-            override fun getApiUrl() = teamcityUrl
-            override fun getAuth() = StandardBasicCredCredentialProvider("admin", "admin")
-        })
+        private val teamcityClient =
+            TeamcityClassicClient(
+                object : ClientParametersProvider {
+                    override fun getApiUrl() = teamcityUrl
 
-        private val httpClient = HttpClient.newBuilder()
-            .connectTimeout(Duration.ofSeconds(10))
-            .build()
+                    override fun getAuth() = StandardBasicCredCredentialProvider("admin", "admin")
+                },
+            )
+
+        private val httpClient =
+            HttpClient
+                .newBuilder()
+                .connectTimeout(Duration.ofSeconds(10))
+                .build()
 
         private fun waitForTeamcityReady() {
             val deadline = System.currentTimeMillis() + READINESS_TIMEOUT
-            val request = HttpRequest.newBuilder()
-                .uri(URI("$teamcityUrl/app/rest/server/version"))
-                .header("Origin", teamcityUrl)
-                .header("Authorization", TEAMCITY_AUTHORIZATION)
-                .header("Accept", "text/plain")
-                .timeout(Duration.ofSeconds(30))
-                .method("GET", HttpRequest.BodyPublishers.noBody())
-                .build()
+            val request =
+                HttpRequest
+                    .newBuilder()
+                    .uri(URI("$teamcityUrl/app/rest/server/version"))
+                    .header("Origin", teamcityUrl)
+                    .header("Authorization", TEAMCITY_AUTHORIZATION)
+                    .header("Accept", "text/plain")
+                    .timeout(Duration.ofSeconds(30))
+                    .method("GET", HttpRequest.BodyPublishers.noBody())
+                    .build()
             while (System.currentTimeMillis() < deadline) {
                 try {
                     val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
@@ -182,7 +214,7 @@ class TriggerTest {
                 Thread.sleep(READINESS_POLL_INTERVAL)
             }
             throw RuntimeException(
-                "TeamCity REST API at $teamcityUrl did not become ready within ${READINESS_TIMEOUT / 1000}s"
+                "TeamCity REST API at $teamcityUrl did not become ready within ${READINESS_TIMEOUT / 1000}s",
             )
         }
 
@@ -210,7 +242,8 @@ class TriggerTest {
                 return lastResponse
             }
             throw RuntimeException(
-                "Request to ${request.uri()} failed after $RETRY_ATTEMPTS attempts", lastException
+                "Request to ${request.uri()} failed after $RETRY_ATTEMPTS attempts",
+                lastException,
             )
         }
 
@@ -221,7 +254,8 @@ class TriggerTest {
             // TD-003: switch to TeamcityClient agents API once supported (see docs/TECH_DEBT.md).
             with(
                 sendWithRetry(
-                    HttpRequest.newBuilder()
+                    HttpRequest
+                        .newBuilder()
                         .uri(URI("$teamcityApiUrl/agents/name:test-agent/authorized"))
                         .header("Origin", teamcityUrl)
                         .header("Authorization", TEAMCITY_AUTHORIZATION)
@@ -233,7 +267,7 @@ class TriggerTest {
             ) {
                 if (statusCode() / 100 != 2) {
                     throw RuntimeException(
-                        "Unable to authorize 'test-agent': status=${statusCode()}\n${body()}"
+                        "Unable to authorize 'test-agent': status=${statusCode()}\n${body()}",
                     )
                 }
             }

--- a/ft/src/ft/kotlin/org/octopusden/octopus/releasemanagementservice/TriggerTest.kt
+++ b/ft/src/ft/kotlin/org/octopusden/octopus/releasemanagementservice/TriggerTest.kt
@@ -1,9 +1,11 @@
 package org.octopusden.octopus.releasemanagementservice
 
+import java.io.IOException
 import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
+import java.time.Duration
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
@@ -29,18 +31,8 @@ class TriggerTest {
                   status: RELEASE
             """.trimIndent()
         )
-        Thread.sleep(DEFAULT_TEAMCITY_TRIGGER_POLLING_INTERVAL)
         // TD-002: switch to TeamcityClient builds API once supported (see docs/TECH_DEBT.md).
-        with(readBuilds(buildType.id)) {
-            Assertions.assertTrue(
-                statusCode() / 100 == 2,
-                "Unable to get builds of build type '${buildType.id}':\n${body()}"
-            )
-            Assertions.assertTrue(
-                body().contains("\"count\":1,"),
-                "Number of builds of build type '${buildType.id}' is not equals to 1:\n${body()}"
-            )
-        }
+        pollBuildsUntilCount(buildType.id, expectedCount = 1)
     }
 
     @Test
@@ -53,18 +45,8 @@ class TriggerTest {
                   inReleaseBranch: true
             """.trimIndent()
         )
-        Thread.sleep(DEFAULT_TEAMCITY_TRIGGER_POLLING_INTERVAL)
         // TD-002: switch to TeamcityClient builds API once supported (see docs/TECH_DEBT.md).
-        with(readBuilds(buildType.id)) {
-            Assertions.assertTrue(
-                statusCode() / 100 == 2,
-                "Unable to get builds of build type '${buildType.id}':\n${body()}"
-            )
-            Assertions.assertTrue(
-                body().contains("\"count\":1,"),
-                "Number of builds of build type '${buildType.id}' is not equals to 1:\n${body()}"
-            )
-        }
+        pollBuildsUntilCount(buildType.id, expectedCount = 1)
     }
 
     @Test
@@ -92,17 +74,27 @@ class TriggerTest {
                 "Expected 0 builds during quiet period, but got:\n${body()}"
             )
         }
-        Thread.sleep(DEFAULT_TEAMCITY_TRIGGER_POLLING_INTERVAL)
-        with(readBuilds(buildType.id)) {
+        pollBuildsUntilCount(buildType.id, expectedCount = 1, failureMessage = "Expected 1 build after quiet period elapsed")
+    }
+
+    private fun pollBuildsUntilCount(buildTypeId: String, expectedCount: Int, failureMessage: String? = null) {
+        val deadline = System.currentTimeMillis() + BUILDS_POLL_TIMEOUT
+        var lastBody = ""
+        while (System.currentTimeMillis() < deadline) {
+            val response = readBuilds(buildTypeId)
             Assertions.assertTrue(
-                statusCode() / 100 == 2,
-                "Unable to get builds of build type '${buildType.id}':\n${body()}"
+                response.statusCode() / 100 == 2,
+                "Unable to get builds of build type '$buildTypeId': status=${response.statusCode()}\n${response.body()}"
             )
-            Assertions.assertTrue(
-                body().contains("\"count\":1,"),
-                "Expected 1 build after quiet period elapsed, but got:\n${body()}"
-            )
+            lastBody = response.body()
+            if (lastBody.contains("\"count\":$expectedCount,")) {
+                return
+            }
+            Thread.sleep(BUILDS_POLL_INTERVAL)
         }
+        Assertions.fail<Unit>(
+            "${failureMessage ?: "Number of builds of build type '$buildTypeId' is not equals to $expectedCount"}:\n$lastBody"
+        )
     }
 
     private fun createBuildType(name: String, triggerSelector: String, quietPeriod: String = "0"): TeamcityBuildType {
@@ -153,32 +145,96 @@ class TriggerTest {
         val teamcityApiUrl = "$teamcityUrl/app/rest/2018.1"
         const val DEFAULT_TEAMCITY_TRIGGER_POLLING_INTERVAL = 60000L
         const val TEAMCITY_AUTHORIZATION = "Basic YWRtaW46YWRtaW4="
+        private const val READINESS_POLL_INTERVAL = 5000L
+        private const val READINESS_TIMEOUT = 180000L
+        private const val BUILDS_POLL_INTERVAL = 5000L
+        private const val BUILDS_POLL_TIMEOUT = 180000L
+        private const val RETRY_ATTEMPTS = 5
+        private val RETRY_DELAYS = longArrayOf(1000, 2000, 4000, 8000, 16000)
 
         private val teamcityClient = TeamcityClassicClient(object : ClientParametersProvider {
             override fun getApiUrl() = teamcityUrl
             override fun getAuth() = StandardBasicCredCredentialProvider("admin", "admin")
         })
 
-        private val httpClient = HttpClient.newHttpClient()
+        private val httpClient = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(10))
+            .build()
+
+        private fun waitForTeamcityReady() {
+            val deadline = System.currentTimeMillis() + READINESS_TIMEOUT
+            val request = HttpRequest.newBuilder()
+                .uri(URI("$teamcityUrl/app/rest/server/version"))
+                .header("Origin", teamcityUrl)
+                .header("Authorization", TEAMCITY_AUTHORIZATION)
+                .header("Accept", "text/plain")
+                .timeout(Duration.ofSeconds(30))
+                .method("GET", HttpRequest.BodyPublishers.noBody())
+                .build()
+            while (System.currentTimeMillis() < deadline) {
+                try {
+                    val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
+                    if (response.statusCode() / 100 == 2) {
+                        return
+                    }
+                } catch (_: IOException) {
+                }
+                Thread.sleep(READINESS_POLL_INTERVAL)
+            }
+            throw RuntimeException(
+                "TeamCity REST API at $teamcityUrl did not become ready within ${READINESS_TIMEOUT / 1000}s"
+            )
+        }
+
+        private fun sendWithRetry(request: HttpRequest): HttpResponse<String> {
+            var lastException: Exception? = null
+            var lastResponse: HttpResponse<String>? = null
+            for (attempt in 0 until RETRY_ATTEMPTS) {
+                try {
+                    val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
+                    if (response.statusCode() / 100 == 2) {
+                        return response
+                    }
+                    lastResponse = response
+                    if (response.statusCode() / 100 != 5) {
+                        return response
+                    }
+                } catch (e: IOException) {
+                    lastException = e
+                }
+                if (attempt < RETRY_ATTEMPTS - 1) {
+                    Thread.sleep(RETRY_DELAYS[attempt])
+                }
+            }
+            if (lastResponse != null) {
+                return lastResponse
+            }
+            throw RuntimeException(
+                "Request to ${request.uri()} failed after $RETRY_ATTEMPTS attempts", lastException
+            )
+        }
 
         @JvmStatic
         @BeforeAll
         fun beforeAll() {
+            waitForTeamcityReady()
             // TD-003: switch to TeamcityClient agents API once supported (see docs/TECH_DEBT.md).
             with(
-                httpClient.send(
+                sendWithRetry(
                     HttpRequest.newBuilder()
                         .uri(URI("$teamcityApiUrl/agents/name:test-agent/authorized"))
                         .header("Origin", teamcityUrl)
                         .header("Authorization", TEAMCITY_AUTHORIZATION)
                         .header("Content-Type", "text/plain")
+                        .timeout(Duration.ofSeconds(30))
                         .method("PUT", HttpRequest.BodyPublishers.ofString("true"))
                         .build(),
-                    HttpResponse.BodyHandlers.ofString(),
                 ),
             ) {
                 if (statusCode() / 100 != 2) {
-                    throw RuntimeException("Unable to authorize 'test-agent':\n${body()}")
+                    throw RuntimeException(
+                        "Unable to authorize 'test-agent': status=${statusCode()}\n${body()}"
+                    )
                 }
             }
         }

--- a/ft/src/ft/kotlin/org/octopusden/octopus/releasemanagementservice/UtilityControllerTest.kt
+++ b/ft/src/ft/kotlin/org/octopusden/octopus/releasemanagementservice/UtilityControllerTest.kt
@@ -3,10 +3,13 @@ package org.octopusden.octopus.releasemanagementservice
 import org.octopusden.octopus.releasemanagementservice.client.common.dto.MandatoryUpdateDTO
 import org.octopusden.octopus.releasemanagementservice.client.common.dto.MandatoryUpdateResponseDTO
 
-class UtilityControllerTest : BaseUtilityControllerTest(), BaseReleaseManagementServiceFuncTest {
-
+class UtilityControllerTest :
+    BaseUtilityControllerTest(),
+    BaseReleaseManagementServiceFuncTest {
     override fun getObjectMapper() = TestUtil.mapper
 
-    override fun createMandatoryUpdate(dryRun: Boolean, dto: MandatoryUpdateDTO): MandatoryUpdateResponseDTO =
-        TestUtil.client.createMandatoryUpdate(dryRun, dto)
+    override fun createMandatoryUpdate(
+        dryRun: Boolean,
+        dto: MandatoryUpdateDTO,
+    ): MandatoryUpdateResponseDTO = TestUtil.client.createMandatoryUpdate(dryRun, dto)
 }

--- a/okd/teamcity.yaml
+++ b/okd/teamcity.yaml
@@ -27,10 +27,12 @@ objects:
               protocol: TCP
           readinessProbe:
             httpGet:
-              path: /login.html
+              path: /app/rest/server/version
               port: 8111
             initialDelaySeconds: 60
             periodSeconds: 10
+            timeoutSeconds: 10
+            failureThreshold: 30
           volumeMounts:
             - name: teamcity${TEAMCITY_ID}-data
               mountPath: /data/teamcity_server/datadir


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Mock server startup now includes readiness checks and retried resets for more reliable test environments.
  * Tests use polling and retrying reads instead of fixed sleeps to reduce flakiness.
  * TeamCity readiness probe updated to a version endpoint with increased failure threshold for robustness.

* **Refactor**
  * Formatting and readability improvements across test utilities and test classes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

  ## Summary
  - Harden FT against OKD timing variance by adding readiness polls, retry with exponential backoff, and bounded polling loops to replace fixed `Thread.sleep` + single assertions   
  - Add `waitForMockServerReady()` and `resetWithRetry()` in `MigrateMockData.kt` to handle MockServer startup delays                                                                
  - Change TeamCity readinessProbe from `/login.html` to `/app/rest/server/version` with increased timeout/threshold                                                                 
  - Tolerate transient 5xx (502 Bad Gateway) from OKD router during build polling                                                                                                    
  - Fix KtLint violations across FT source set  