### PR TITLE
chore(ci): bump octopus-base + octopus-quality to 2.4.1 (Phase 4)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   run-build-and-deploy:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.4.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.4.1
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   run-build-and-deploy:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.3.5
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.4.0
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   run-build-and-deploy:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.3.4
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.3.5
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.3.4
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.3.5
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
       artifact-pattern: "octopus/release-management-service/release-management-service/_VER_/release-management-service-_VER_.jar"

--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.4.0
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.4.1
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
       artifact-pattern: "octopus/release-management-service/release-management-service/_VER_/release-management-service-_VER_.jar"

--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.3.5
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.4.0
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
       artifact-pattern: "octopus/release-management-service/release-management-service/_VER_/release-management-service-_VER_.jar"

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -24,6 +24,6 @@ jobs:
     needs: [build, quality, security]
     runs-on: ubuntu-latest
     steps:
-      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.3.5
+      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.4.0
         with:
           needs: ${{ toJson(needs) }}

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -24,6 +24,6 @@ jobs:
     needs: [build, quality, security]
     runs-on: ubuntu-latest
     steps:
-      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.3.4
+      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.3.5
         with:
           needs: ${{ toJson(needs) }}

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -24,6 +24,6 @@ jobs:
     needs: [build, quality, security]
     runs-on: ubuntu-latest
     steps:
-      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.4.0
+      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.4.1
         with:
           needs: ${{ toJson(needs) }}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   quality:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.4.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.4.1
     with:
       java-version: "21"
       # ORMS excludes :release-management-service:test from quality gate (heavy Spring Boot

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   quality:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.3.5
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.4.0
     with:
       java-version: "21"
       # ORMS excludes :release-management-service:test from quality gate (heavy Spring Boot

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   quality:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.3.4
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.3.5
     with:
       java-version: "21"
       # ORMS excludes :release-management-service:test from quality gate (heavy Spring Boot

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.3.4
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.3.5
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.3.5
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.4.0
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.4.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.4.1
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   security:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.3.5
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.4.0
     with:
       java-version: "21"
       enable-codeql: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   security:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.3.4
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.3.5
     with:
       java-version: "21"
       enable-codeql: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   security:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.4.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.4.1
     with:
       java-version: "21"
       enable-codeql: true

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ detekt.version=1.23.5
 ktlint-gradle.version=14.0.1
 kover.version=0.9.4
 owasp-dependency-check.version=12.2.0
-octopus-quality.version=2.3.5
+octopus-quality.version=2.4.0
 jakarta-validation.version=3.1.1
 
 coverage.line.min=22

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ detekt.version=1.23.5
 ktlint-gradle.version=14.0.1
 kover.version=0.9.4
 owasp-dependency-check.version=12.2.0
-octopus-quality.version=2.4.0
+octopus-quality.version=2.4.1
 jakarta-validation.version=3.1.1
 
 coverage.line.min=22

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ detekt.version=1.23.5
 ktlint-gradle.version=14.0.1
 kover.version=0.9.4
 owasp-dependency-check.version=12.2.0
-octopus-quality.version=2.3.4
+octopus-quality.version=2.3.5
 jakarta-validation.version=3.1.1
 
 coverage.line.min=22


### PR DESCRIPTION
Aligns ORMS on the **Phase 4 LTS pin `2.3.5`** (was 2.3.4).

- 6 reusable-workflow refs `octopusden/octopus-base/...@v2.3.4` → `@v2.3.5`
- `gradle.properties`: `octopus-quality.version=2.3.4` → `2.3.5`

2.3.4→2.3.5 plugin delta is #142 (SpotBugs gated to Java modules + Java-25 engine) — low risk for this Kotlin service. Part of Phase 4 Batch A (align already-adopted repos on one LTS before mass rollout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)