### PR TITLE
chore(publish): stop publishing the server bootJar to Maven Central

### DIFF
--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -11,5 +11,8 @@ jobs:
     uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.4.1
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
-      artifact-pattern: "octopus/release-management-service/release-management-service/_VER_/release-management-service-_VER_.jar"
+      # Gate registration on a module that is actually published to Central. The server jar is
+      # no longer published (it is a deployable; see server/build.gradle.kts), so poll :client —
+      # a consumed library that ships on every release.
+      artifact-pattern: "octopus/release-management-service/client/_VER_/client-_VER_.jar"
     secrets: inherit

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -10,43 +10,11 @@ plugins {
     `maven-publish`
 }
 
-publishing {
-    publications {
-        create<MavenPublication>("bootJar") {
-            artifact(tasks.getByName("bootJar"))
-            from(components["java"])
-            pom {
-                name.set(project.name)
-                description.set("Octopus module: ${project.name}")
-                url.set("https://github.com/octopusden/octopus-release-management-service.git")
-                licenses {
-                    license {
-                        name.set("The Apache License, Version 2.0")
-                        url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
-                    }
-                }
-                scm {
-                    url.set("https://github.com/kzaporozhtsev/octopus-release-management-service.git")
-                    connection.set("scm:git://github.com/octopusden/octopus-release-management-service.git")
-                }
-                developers {
-                    developer {
-                        id.set("octopus")
-                        name.set("octopus")
-                    }
-                }
-            }
-        }
-    }
-}
-
-signing {
-    isRequired = project.ext["signingRequired"] as Boolean
-    val signingKey: String? by project
-    val signingPassword: String? by project
-    useInMemoryPgpKeys(signingKey, signingPassword)
-    sign(publishing.publications["bootJar"])
-}
+// Not published to Maven Central: the server is a deployable, its deliverable is the docker
+// image on ghcr, and nothing consumes it as a Maven dependency. Declaring no publication is
+// what actually keeps it out — publishToSonatype then has nothing to upload for this module.
+// The consumed libraries (:client, :common, :legacy-releng-client, :teamcity-plugin) and
+// :automation keep publishing from their own build scripts.
 
 fun String.getExt() = project.ext[this] as String
 

--- a/server/ktlint-baseline.xml
+++ b/server/ktlint-baseline.xml
@@ -2,18 +2,18 @@
 <baseline version="1.0">
     <file name="build.gradle.kts">
         <error line="1" column="1" source="standard:import-ordering" />
-        <error line="54" column="48" source="standard:chain-method-continuation" />
-        <error line="54" column="82" source="standard:chain-method-continuation" />
-        <error line="54" column="94" source="standard:paren-spacing" />
-        <error line="61" column="68" source="standard:trailing-comma-on-call-site" />
-        <error line="62" column="10" source="standard:trailing-comma-on-call-site" />
-        <error line="72" column="64" source="standard:curly-spacing" />
-        <error line="78" column="24" source="standard:wrapping" />
-        <error line="81" column="80" source="standard:trailing-comma-on-call-site" />
-        <error line="82" column="9" source="standard:wrapping" />
-        <error line="142" column="20" source="standard:argument-list-wrapping" />
-        <error line="142" column="141" source="standard:max-line-length" />
-        <error line="142" column="147" source="standard:argument-list-wrapping" />
+        <error line="22" column="48" source="standard:chain-method-continuation" />
+        <error line="22" column="82" source="standard:chain-method-continuation" />
+        <error line="22" column="94" source="standard:paren-spacing" />
+        <error line="29" column="68" source="standard:trailing-comma-on-call-site" />
+        <error line="30" column="10" source="standard:trailing-comma-on-call-site" />
+        <error line="40" column="64" source="standard:curly-spacing" />
+        <error line="46" column="24" source="standard:wrapping" />
+        <error line="49" column="80" source="standard:trailing-comma-on-call-site" />
+        <error line="50" column="9" source="standard:wrapping" />
+        <error line="110" column="20" source="standard:argument-list-wrapping" />
+        <error line="110" column="141" source="standard:max-line-length" />
+        <error line="110" column="147" source="standard:argument-list-wrapping" />
     </file>
     <file name="src/main/kotlin/org/octopusden/octopus/releasemanagementservice/actuator/LegacyRelengIndicator.kt">
         <error line="10" column="55" source="standard:trailing-comma-on-declaration-site" />


### PR DESCRIPTION
## Why

The org is over Maven Central's **monthly** publishing limits (Release Size 1.21 GB vs 80 MB, File Count 10 094 vs 1 000). Measured against Central, ORMS uploads **85.12 MB in 340 files per release** — more than the entire monthly size limit in a single release.

| artifact | files | size | consumers | |
|---|--:|--:|---|---|
| **release-management-service** (server bootJar) | 60 | **55.31 MB** | none | **drop** |
| automation (own group) | 70 | 21.11 MB | TeamCity metarunner | keep |
| release-management-teamcity-plugin | 60 | 8.55 MB | — | keep (see note) |
| common | 50 | 0.08 MB | dms, employee, reporting, vcs-facade | keep |
| client | 50 | 0.04 MB | CRS, dms, employee, vcs-facade, sonar | keep |
| legacy-releng-client | 50 | 0.02 MB | — | keep |

The server is a **deployable** — its deliverable is the docker image on ghcr, and nothing consumes it as a Maven dependency (verified across the org and in this repo: no build file, doc, docker-compose or `ft` config resolves the server jar by coordinate).

Unlike a UI/app repo, ORMS **cannot** skip Central wholesale (`publish-to-nexus: false` would break real consumers of `:client`/`:common`), so this is artifact-level: drop only the server publication.

## What

- **`server/build.gradle.kts`**: remove the `bootJar` publication and the `signing` block that signed it. Declaring **no publication** is what actually keeps a module out of Central — `publishToSonatype` then has nothing to upload for it. `maven-publish` stays applied; `bootJar`, docker and oc-template tasks are untouched.
- **`.github/workflows/check-and-register.yml`**: the release-log gate polled Central for the server jar (45 × 2 min), which will no longer appear — it would hang ~90 min and fail. Re-pointed at `:client`, a consumed library published on every release, which preserves the "wait until it's really on Central" semantics. Path verified live: `…/release-management-service/client/2.0.46/client-2.0.46.jar` → **200 OK**.
- **`server/ktlint-baseline.xml`**: regenerated. The baseline pins violations **by line number**, and removing the publication block shifted the file by 32 lines, surfacing pre-existing debt. The regenerated file has the **same 12 entries and same rules**, only renumbered — no new violations, nothing suppressed that wasn't already.

## Kept on purpose: :automation

Its TeamCity metarunner resolves the fat jar from a Maven repo at build time:

```xml
-Dartifact=${group}:${name}:${version}:jar:all
```

(`automation/metarunners/OctopusReleaseManagementAutomation.xml`) — a plain dependency search doesn't reveal this, so it must stay published.

## Effect

| | before | after |
|---|--:|--:|
| files / release | 340 | **280** |
| MB / release | 85.12 | **29.81** |
| **saved** | | **−55.31 MB, −60 files per release** |

## Verification

- `./gradlew build -x test -x docker* -x oc*` → **BUILD SUCCESSFUL**, `:release-management-service:ktlintKotlinScriptCheck` re-ran and passed, `bootJar` still builds
- `./gradlew publishToMavenLocal --dry-run` → exactly **5** publications (`automation`, `client`, `common`, `legacy-releng-client`, `release-management-teamcity-plugin`); `:server` has none
- Independent review (Sonnet): no blockers/majors. Confirmed `signingRequired` is still read by the other modules (unused for `:server`, no error), no reference anywhere to `publications["bootJar"]` / `:server:publish*` / `signBootJarPublication`, and the re-pointed poll path resolves 200.

## Note / possible follow-up

`release-management-teamcity-plugin` (8.55 MB zip) has no discoverable consumers, but it's a TeamCity plugin and how TC installs it isn't visible from the repo. After the CRS/ORMS metarunner findings I did **not** drop it without evidence — if we know TC doesn't fetch it from Central, that's another −8.5 MB per release.

Part of an org-wide effort: portal#203 (merged, −461 MB/mo), CRS#456, api-gateway#34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation to validate and register the published client artifact only after a successful workflow run.
  * Clarified distribution of the server component as a container image rather than a Maven package.
  * Refreshed code-quality tracking to align with the latest build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->