### PR TITLE
chore(publish): stop publishing the server bootJar and move octopus-base to v2.6.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   run-build-and-deploy:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.6.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.6.2
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   run-build-and-deploy:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.5.2
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   run-build-and-deploy:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.5.2
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.6.1
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.5.2
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
       artifact-pattern: "octopus/release-management-service/release-management-service/_VER_/release-management-service-_VER_.jar"

--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.5.2
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.6.1
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
       # Gate registration on a module that is actually published to Central. The server jar is

--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -11,5 +11,8 @@ jobs:
     uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.5.2
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
-      artifact-pattern: "octopus/release-management-service/release-management-service/_VER_/release-management-service-_VER_.jar"
+      # Gate registration on a module that is actually published to Central. The server jar is
+      # no longer published (it is a deployable; see server/build.gradle.kts), so poll :client —
+      # a consumed library that ships on every release.
+      artifact-pattern: "octopus/release-management-service/client/_VER_/client-_VER_.jar"
     secrets: inherit

--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.6.1
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.6.2
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
       # Gate registration on a module that is actually published to Central. The server jar is

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -24,6 +24,6 @@ jobs:
     needs: [build, quality, security]
     runs-on: ubuntu-latest
     steps:
-      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.4.1
+      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.5.2
         with:
           needs: ${{ toJson(needs) }}

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -24,6 +24,6 @@ jobs:
     needs: [build, quality, security]
     runs-on: ubuntu-latest
     steps:
-      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.5.2
+      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.6.1
         with:
           needs: ${{ toJson(needs) }}

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -24,6 +24,6 @@ jobs:
     needs: [build, quality, security]
     runs-on: ubuntu-latest
     steps:
-      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.6.1
+      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.6.2
         with:
           needs: ${{ toJson(needs) }}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   quality:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.6.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.6.2
     with:
       java-version: "21"
       # ORMS excludes :release-management-service:test from quality gate (heavy Spring Boot

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   quality:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.5.2
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.6.1
     with:
       java-version: "21"
       # ORMS excludes :release-management-service:test from quality gate (heavy Spring Boot

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   quality:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.5.2
     with:
       java-version: "21"
       # ORMS excludes :release-management-service:test from quality gate (heavy Spring Boot

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.6.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.6.2
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.5.2
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,12 @@ jobs:
       #     ${group}:${name}:${version}:jar:all (automation/metarunners/
       #     OctopusReleaseManagementAutomation.xml), so the shadow jar must stay published.
       #   release-management-teamcity-plugin — an 8.5 MB TeamCity plugin bundle, above the
-      #     8 MB default. Its users install it into TeamCity from outside this GitHub
-      #     organisation, so it is exempted rather than dropped.
+      #     8 MB default. Exempted to keep this change behaviour-preserving, NOT because a
+      #     consumer is known: nothing in this organisation resolves it from a Maven
+      #     repository (the only in-repo user, ft's deployTeamcity2022Plugin, takes it from
+      #     the project's `distributions` configuration), and the GitHub releases carry no
+      #     assets. Whether Maven Central is still a needed install channel for TeamCity
+      #     admins is an open question in the PR — if it is not, dropping this publication
+      #     saves a further 60 files and 8.5 MB per release.
       fat-jar-publication-allowlist: automation,release-management-teamcity-plugin
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.5.2
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.6.1
     with:
       flow-type: hybrid
       java-version: '21'
@@ -14,4 +14,13 @@ jobs:
       build-version: ${{ github.event.client_payload.project_version }}
       docker-image: release-management-service
       skip-extra-tasks: ft
+      # Exempt from the Maven Central publication guard. Everything else this repository
+      # publishes is a thin library jar, so the guard's defaults apply unchanged.
+      #   automation — the TeamCity metarunner resolves it from a Maven repository as
+      #     ${group}:${name}:${version}:jar:all (automation/metarunners/
+      #     OctopusReleaseManagementAutomation.xml), so the shadow jar must stay published.
+      #   release-management-teamcity-plugin — an 8.5 MB TeamCity plugin bundle, above the
+      #     8 MB default. Its users install it into TeamCity from outside this GitHub
+      #     organisation, so it is exempted rather than dropped.
+      fat-jar-publication-allowlist: automation,release-management-teamcity-plugin
     secrets: inherit

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   security:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.5.2
     with:
       java-version: "21"
       enable-codeql: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   security:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.6.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.6.2
     with:
       java-version: "21"
       enable-codeql: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   security:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.5.2
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.6.1
     with:
       java-version: "21"
       enable-codeql: true

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ detekt.version=1.23.5
 ktlint-gradle.version=14.0.1
 kover.version=0.9.4
 owasp-dependency-check.version=12.2.0
-octopus-quality.version=2.4.1
+octopus-quality.version=2.6.1
 jakarta-validation.version=3.1.1
 
 coverage.line.min=22

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ detekt.version=1.23.5
 ktlint-gradle.version=14.0.1
 kover.version=0.9.4
 owasp-dependency-check.version=12.2.0
-octopus-quality.version=2.6.1
+octopus-quality.version=2.6.2
 jakarta-validation.version=3.1.1
 
 coverage.line.min=22

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -10,43 +10,11 @@ plugins {
     `maven-publish`
 }
 
-publishing {
-    publications {
-        create<MavenPublication>("bootJar") {
-            artifact(tasks.getByName("bootJar"))
-            from(components["java"])
-            pom {
-                name.set(project.name)
-                description.set("Octopus module: ${project.name}")
-                url.set("https://github.com/octopusden/octopus-release-management-service.git")
-                licenses {
-                    license {
-                        name.set("The Apache License, Version 2.0")
-                        url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
-                    }
-                }
-                scm {
-                    url.set("https://github.com/kzaporozhtsev/octopus-release-management-service.git")
-                    connection.set("scm:git://github.com/octopusden/octopus-release-management-service.git")
-                }
-                developers {
-                    developer {
-                        id.set("octopus")
-                        name.set("octopus")
-                    }
-                }
-            }
-        }
-    }
-}
-
-signing {
-    isRequired = project.ext["signingRequired"] as Boolean
-    val signingKey: String? by project
-    val signingPassword: String? by project
-    useInMemoryPgpKeys(signingKey, signingPassword)
-    sign(publishing.publications["bootJar"])
-}
+// Not published to Maven Central: the server is a deployable, its deliverable is the docker
+// image on ghcr, and nothing consumes it as a Maven dependency. Declaring no publication is
+// what actually keeps it out — publishToSonatype then has nothing to upload for this module.
+// The consumed libraries (:client, :common, :legacy-releng-client, :teamcity-plugin) and
+// :automation keep publishing from their own build scripts.
 
 fun String.getExt() = project.ext[this] as String
 

--- a/server/ktlint-baseline.xml
+++ b/server/ktlint-baseline.xml
@@ -2,18 +2,18 @@
 <baseline version="1.0">
     <file name="build.gradle.kts">
         <error line="1" column="1" source="standard:import-ordering" />
-        <error line="54" column="48" source="standard:chain-method-continuation" />
-        <error line="54" column="82" source="standard:chain-method-continuation" />
-        <error line="54" column="94" source="standard:paren-spacing" />
-        <error line="61" column="68" source="standard:trailing-comma-on-call-site" />
-        <error line="62" column="10" source="standard:trailing-comma-on-call-site" />
-        <error line="72" column="64" source="standard:curly-spacing" />
-        <error line="78" column="24" source="standard:wrapping" />
-        <error line="81" column="80" source="standard:trailing-comma-on-call-site" />
-        <error line="82" column="9" source="standard:wrapping" />
-        <error line="142" column="20" source="standard:argument-list-wrapping" />
-        <error line="142" column="141" source="standard:max-line-length" />
-        <error line="142" column="147" source="standard:argument-list-wrapping" />
+        <error line="22" column="48" source="standard:chain-method-continuation" />
+        <error line="22" column="82" source="standard:chain-method-continuation" />
+        <error line="22" column="94" source="standard:paren-spacing" />
+        <error line="29" column="68" source="standard:trailing-comma-on-call-site" />
+        <error line="30" column="10" source="standard:trailing-comma-on-call-site" />
+        <error line="40" column="64" source="standard:curly-spacing" />
+        <error line="46" column="24" source="standard:wrapping" />
+        <error line="49" column="80" source="standard:trailing-comma-on-call-site" />
+        <error line="50" column="9" source="standard:wrapping" />
+        <error line="110" column="20" source="standard:argument-list-wrapping" />
+        <error line="110" column="141" source="standard:max-line-length" />
+        <error line="110" column="147" source="standard:argument-list-wrapping" />
     </file>
     <file name="src/main/kotlin/org/octopusden/octopus/releasemanagementservice/actuator/LegacyRelengIndicator.kt">
         <error line="10" column="55" source="standard:trailing-comma-on-declaration-site" />


### PR DESCRIPTION
> **Retargeted to octopus-base v2.6.2** after this text was first written. Verified before retargeting: the release workflow's `workflow_call` input set is identical between v2.6.1 and v2.6.2, the publication guard step is untouched, and the `octopus-quality` plugin sources do not move — so the verification recorded below still applies. Local verification was re-run at v2.6.2.

## What

Stops publishing the service bootJar to Maven Central, and moves every octopus-base reference to **v2.6.2** — in one PR, because splitting them makes merge order load-bearing (see *Why one PR*).

Supersedes #72 (bootJar removal) and #73's original v2.5.2 target; #72 can be closed in favour of this one.

## Measured, not estimated

`measure-central-footprint.py --from-gradle` (publishes to a throwaway local repository and reads the real coordinates, so it covers every groupId — including `org.octopusden.octopus.automation.release-management`, which the repo's own group does not reveal):

| | files / release | size / release |
|---|---|---|
| before | 330 | 85.12 MB |
| after | 280 | 29.81 MB |
| **change** | **−50** | **−55.31 MB** |

The whole reduction is one artifact: `release-management-service-2.0.46.jar`, a 55.2 MB Spring Boot fat jar.

## Dropped, with the evidence

**`release-management-service`** — no consumer resolves it as a Maven dependency anywhere in the organisation. It is a deployable: the docker image is how it ships, and that is untouched. The `bootJar` task itself still exists and is still built; only the `MavenPublication` for it is gone.

## Kept on purpose

| artifact | why |
|---|---|
| `client`, `common`, `legacy-releng-client` | consumed as libraries; thin jars, ≤ 0.08 MB each |
| `automation` (21 MB `-all.jar`) | the TeamCity metarunner resolves it as `${group}:${name}:${version}:jar:all` — `automation/metarunners/OctopusReleaseManagementAutomation.xml:17`. Dropping it breaks TC automation |
| `release-management-teamcity-plugin` (8.5 MB zip) | kept to stay behaviour-preserving — **see the open question below** |

## The guard exception, and why it is needed

From v2.6.0 the shared release workflow fails a release when a published artifact carries an `-all` classifier, contains `BOOT-INF/`, or exceeds `max-central-artifact-mb` (default 8). `publish-to-nexus` defaults to `true` and this repo does not override it, so **the guard runs on every real release here** — verified against the workflow source, not assumed.

Two artifacts trip it and must keep publishing, so they are named in `fat-jar-publication-allowlist`. The threshold is deliberately left at 8: raising it would weaken the guard for every artifact instead of exempting two.

## Why one PR

With these split, merging the bump first would fail the very next release — on the 21 MB `automation` jar, and on the 55 MB bootJar until the removal lands. That failure surfaces at release time, long after review, and only if someone remembers the order. Together, there is no ordering to remember.

## Open question — the TeamCity plugin zip

The 8.5 MB `release-management-teamcity-plugin` zip is exempted rather than dropped, but **no consumer of it via Maven Central could be found**:

- nothing in the organisation resolves it by Maven coordinates;
- the only in-repo user, `ft`'s `deployTeamcity2022Plugin`, takes it from the project's own `distributions` configuration (`ft/build.gradle.kts:207`), not from Central;
- the GitHub releases carry no assets.

A TeamCity admin fetching it by hand would leave no trace in this repository, so absence of evidence is not evidence of absence — hence keeping it. **If Central is not a needed install channel for it, dropping that publication saves a further 60 files and 8.5 MB per release.** Please confirm either way.

## Verified

- `./gradlew build` green. The `ft` compose stack was **excluded**: its `mockserver` and `teamcity-agent` images are amd64-only and the machine is arm64, so it cannot run locally at all. CI covers it.
- Coordinate sets measured before and after: exactly one coordinate disappears.
- `check-and-register.yml` repointed from the removed server jar to `client`, and the resulting Central URL verified to return 200. Left unchanged it would have polled a permanently missing file for ~90 minutes and failed.
- `server/ktlint-baseline.xml` entries all shift by exactly −32 lines, matching the removed block; no new suppressions.
- The octopus-quality bump 2.4.1 → 2.6.2 changes no production plugin code (only a functional test between those tags), so existing baselines stay valid.
- Every octopus-base reference moved together — six workflow/action refs plus `octopus-quality.version` — so the repo does not straddle two versions of shared CI.

## Not verified locally

The release path itself. The guard, the publish and the registration only exercise on a real release.

Related: octopusden/octopus-base#163.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated shared CI/CD workflows (build, quality, release, security, registration, merge validation) to the latest standardized version.
  * Updated the corresponding Gradle quality version setting.
  * Adjusted release workflow configuration, including artifact targeting and the new publication allowlist.
  * Removed Maven Central publishing/signing for the server module (Docker image remains the external deliverable).
  * Refreshed the Kotlin formatting baseline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
