### PR TITLE
ci: move octopus-base to v2.7.0 and adopt the shared publication policy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   run-build-and-deploy:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.6.2
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.7.0
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.6.2
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.7.0
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
       # Gate registration on a module that is actually published to Central. The server jar is

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -24,6 +24,6 @@ jobs:
     needs: [build, quality, security]
     runs-on: ubuntu-latest
     steps:
-      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.6.2
+      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.7.0
         with:
           needs: ${{ toJson(needs) }}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   quality:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.6.2
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.7.0
     with:
       java-version: "21"
       # ORMS excludes :release-management-service:test from quality gate (heavy Spring Boot

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.6.2
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.7.0
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   security:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.6.2
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.7.0
     with:
       java-version: "21"
       enable-codeql: true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,6 +93,34 @@ kover {
 }
 
 octopusQuality {
+    // Regression guard on what this repository publishes to Maven Central, from octopus-base
+    // v2.7.0. No hand-rolled guard existed here before this change — nothing is being deleted,
+    // this is a straight addition.
+    //
+    // This is deliberately INDEPENDENT of release.yml's fat-jar-publication-allowlist
+    // (`automation,release-management-teamcity-plugin`): that exemption stops the release-time
+    // SIZE guard from inspecting either artifactId at all, so a second oversized artifact added
+    // to either publication would pass that guard unnoticed. The signatures declared below are
+    // the only thing left watching those two — which is why the two mechanisms are
+    // complementary, not redundant.
+    publication {
+        enforceCentralPublications.set(true)
+        centralPublications.set(
+            setOf(
+                ":automation|maven|org.octopusden.octopus.automation.release-management:automation|" +
+                    "[jar, jar:all, jar:javadoc, jar:sources, zip:metarunners]",
+                ":client|maven|org.octopusden.octopus.release-management-service:client|" +
+                    "[jar, jar:javadoc, jar:sources]",
+                ":common|maven|org.octopusden.octopus.release-management-service:common|" +
+                    "[jar, jar:javadoc, jar:sources]",
+                ":legacy-releng-client|maven|org.octopusden.octopus.release-management-service:legacy-releng-client|" +
+                    "[jar, jar:javadoc, jar:sources]",
+                ":release-management-teamcity-plugin|maven|" +
+                    "org.octopusden.octopus.release-management-service:release-management-teamcity-plugin|" +
+                    "[jar, jar:javadoc, jar:sources, zip]",
+            ),
+        )
+    }
     // ORMS: blocking mode (already established)
     kotlin {
         failOnViolation.set(true)

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ detekt.version=1.23.5
 ktlint-gradle.version=14.0.1
 kover.version=0.9.4
 owasp-dependency-check.version=12.2.0
-octopus-quality.version=2.6.2
+octopus-quality.version=2.7.0
 jakarta-validation.version=3.1.1
 
 coverage.line.min=22


### PR DESCRIPTION
## What changed

Three changes:

* all six `octopus-base` workflow refs (`build.yml`, `check-and-register.yml`, `merge-gate.yml`, `quality.yml`, `release.yml`, `security.yml`) and `octopus-quality.version` in `gradle.properties` go to **v2.7.0**;
* `octopusQuality { publication { ... } }` is added, declaring the five coordinates this repository publishes.

**No hand-rolled `verifyCentralPublicationPolicy` existed here** — this is a pure addition, not a replacement. Nothing is being deleted and there is no task-name collision to sequence around.

## `release.yml`'s `fat-jar-publication-allowlist` is untouched — deliberately

`fat-jar-publication-allowlist: automation,release-management-teamcity-plugin` stays exactly as it was. That exemption stops the release-time **size** guard from inspecting either artifactId at all — the exemption covers everything published under those two artifactIds, not just today's known files. So a second oversized artifact added to either publication would pass the release-time guard unnoticed. The artifact **signatures** declared in this PR are the only thing left watching those two specifically. That's why the two mechanisms are complementary rather than redundant — not because either is more authoritative than the other, and it's the reason the declared set matters *more* here than in most repos, not less.

## Where the declared set came from

Taken from the build, not written by hand: declared an empty `centralPublications` set, ran `verifyCentralPublicationPolicy` directly (an empty declared set blocks `publishToMavenLocal`, so the usual `--from-gradle` measurement approach deadlocks here), and copied what it printed as `publishing:`.

```
:automation|maven|org.octopusden.octopus.automation.release-management:automation|[jar, jar:all, jar:javadoc, jar:sources, zip:metarunners]
:client|maven|org.octopusden.octopus.release-management-service:client|[jar, jar:javadoc, jar:sources]
:common|maven|org.octopusden.octopus.release-management-service:common|[jar, jar:javadoc, jar:sources]
:legacy-releng-client|maven|org.octopusden.octopus.release-management-service:legacy-releng-client|[jar, jar:javadoc, jar:sources]
:release-management-teamcity-plugin|maven|org.octopusden.octopus.release-management-service:release-management-teamcity-plugin|[jar, jar:javadoc, jar:sources, zip]
```

Two things read from the build rather than assumed:
* **`:automation`'s groupId is `org.octopusden.octopus.automation.release-management`**, not the `org.octopusden.octopus.release-management-service` every other module here uses.
* **`:release-management-teamcity-plugin`'s project path** is the one `settings.gradle.kts`'s rename produces (`findProject(":teamcity-plugin")?.name = "release-management-teamcity-plugin"`), not the original `:teamcity-plugin` path declared in `include(...)`.

No `java-gradle-plugin` marker publication exists in this repository (it publishes a TeamCity plugin, not a Gradle plugin), so there is no marker axis to declare or test.

## Verified locally (against the real v2.7.0 plugin resolved from Central, all `--no-daemon`)

* **GREEN** with the declared 5-identity set.
* **RED** on the axis `release.yml`'s size guard no longer watches: dropped `jar:all` from `:automation` — one of the two allowlisted artifactIds — task fails, printing declared vs publishing.
* Restored → **GREEN** again, so it is not red in both states.
* `check --dry-run` schedules the task exactly once.
* `ktlintCheck`, `ktlintKotlinScriptCheck`, `detekt` all pass across every module.
* `./gradlew build -x test -x ft:test` — **BUILD SUCCESSFUL**; `validatePublications` separately confirms 1 publication passing Maven Central checks in each of `:automation`, `:client`, `:common`, `:legacy-releng-client`, `:release-management-teamcity-plugin`, and correctly reports no `MavenPublication` in `:release-management-service` (the deployable).

## Not verified locally

**TeamCity has since run and is green** — this line previously said the check was still pending.
Build `…_10CompileUtAuto` finished SUCCESS with **89 tests passed**, and its own `revisions` field reads
`3578c1c00c6720a2b22ce4f6d8a5a6fb21cc6a05` — this PR's head, not an earlier commit. The branch was not
picked up by VCS polling in time, so the build was queued manually rather than waiting; two independent
reviewers re-queried the server and confirmed the same build-to-commit mapping.

Still not verified: publishing to Sonatype for real (no credentials outside the release pipeline), and
OKD/FT teardown timing beyond the FT suite passing inside the TeamCity run above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build, quality, security, release, and merge validation processes to the latest shared workflow version.
  * Updated the quality tooling version to 2.7.0.

* **Quality Improvements**
  * Added validation to ensure published Maven artifacts match their approved signatures on Maven Central.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
